### PR TITLE
fix: Tier 0 correctness — complete validation security fix and clean up :memory: test bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ config.yaml
 # Temporary files
 tmp/
 temp/
+.todos/
+
+# Defensive: prevent regression of the SQLite ":memory:" sentinel being
+# misinterpreted as a filesystem path (see internal/storage/store.go).
+:memory:/

--- a/docs/brainstorms/codebase-punch-list-requirements.md
+++ b/docs/brainstorms/codebase-punch-list-requirements.md
@@ -1,0 +1,237 @@
+# ZeroDayBuddy Codebase Punch List — Requirements
+
+**Date:** 2026-05-10
+**Branch at audit:** `fix/github-issues-9-12-13-14`
+**Audit scope:** full repo (≈30,954 LoC Go, 53 test files, 6 SQL migrations, web template assets)
+**Ranking:** correctness-first (broken → security/safety → leverage → expansion)
+**Source workflow:** `/compound-engineering:ce-brainstorm`
+**Successor:** suitable for `/ce-plan` per tier, or `/ce-work` per item
+
+---
+
+## 1. Goal
+
+Produce a prioritized, actionable backlog of every meaningful gap surfaced by a verification-first audit of the codebase, so future sessions (`ce-plan`, `ce-work`) can pull items off the top without re-discovering context.
+
+The audit answered four sub-questions:
+
+1. **What works?** — capabilities that are implemented and verified.
+2. **What's broken?** — code that fails to build, fails tests, or contains live correctness/security defects.
+3. **What's missing?** — design-level gaps that block real workflows (not just nice-to-haves).
+4. **What's under-implemented?** — capability that is built but unreachable from the user surface (CLI/web).
+
+---
+
+## 2. Audit Summary
+
+**What works (verified by reading current source, not docs):**
+
+| Area | Status |
+|---|---|
+| Architecture | Clean `cmd / internal / pkg` separation; `App` orchestrator wires services with `ensureInitialized` |
+| Storage | SQLite via `internal/storage`; 6 ordered SQL migrations including CVSS fields and auth tables |
+| Recon | 10 scanners present: subfinder, amass, httpx, naabu, katana, wayback, ffuf, nuclei, gitleaks, trivy |
+| Scan service | `internal/scan/service.go` — real implementation with nuclei orchestration, hardened SSRF filter (RFC 1918 + cloud-metadata + IPv6), semaphore concurrency, batch processing, finding ingest |
+| Auth | bcrypt password hashing; JWT with auto-generated 32-byte secret; refresh tokens; SQLStore on shared DB |
+| Reports | JSON + CSV + SARIF v2.1.0 + GitHub integration |
+| Models | Wildcard + CIDR + subdomain scope matching at `pkg/models/models.go:115`; CVSS 3.1/4.0 fields |
+| Rate limiting | Per-service limiter with cleanup ticker |
+| CLI | `init`, `list-programs`, `project`, `recon`, `scan`, `report`, `serve`, `version` all wired |
+| Tests | 22 of 23 test packages pass; only `pkg/validation` fails (build error, not assertion) |
+
+**What's broken or unwired (verified):**
+
+- `pkg/validation/project_test.go` references undefined `matchesDomain` and `extractHost` — `go test ./...` fails to build this package.
+- `pkg/validation/project.go:48` uses `strings.Contains(target, asset.Value)` for scope matching (CWE-bypass-class) — but is **dead code** (only the broken test references `ProjectScope`).
+- `internal/web/server.go` registers only `/health` and a static welcome page; the full handler/middleware stack at `internal/web/handlers/` and `internal/web/middleware/` (auth, errors, ratelimit, security) is **never wired**.
+- `internal/core/:memory:/` and `cmd/zerodaybuddy/:memory:/` — directories accidentally created by something opening SQLite with `":memory:"` as a filename.
+
+**What's stale or misleading:**
+
+- `CLAUDE.md` claims scan service is "currently stub" (false); doesn't mention gitleaks/trivy scanners or SARIF/GitHub report modules.
+- `TODO.md` lists already-completed items as "high priority" (signal handling, JWT secret, log levels, error handling).
+- `CHANGELOG.md` `[Unreleased]` is empty despite Phases 1-4 of modernization having merged.
+- Five `scratch-*.md` files plus `HACKERONE_HACKER_LIMITATIONS.md`, `create_manual_project.sql`, `test_server.py`, `ZERODAYBUDDY_TEST_REPORT.md` clutter the repo root.
+
+---
+
+## 3. The Punch List
+
+Each item: **what** + **where** + **effort (S/M/L)** + **why this rank** + **dependencies**.
+
+### Tier 0 — Broken (fix immediately; blocks other work)
+
+**T0-1. Fix `pkg/validation/project_test.go` build break**
+- Where: `pkg/validation/project_test.go` (untracked)
+- Effort: S
+- Two clean options: (a) implement `matchesDomain` + `extractHost` in `pkg/validation/project.go` and fix `ProjectScope` to use them, or (b) delete the test file as part of T0-2 if `ProjectScope` itself goes.
+- Why first: blocks `go test ./...` from green; signals abandoned in-progress work that confuses future contributors.
+
+**T0-2. Resolve duplicate scope-checking implementations**
+- Where: `pkg/validation/project.go:33` (`ProjectScope`)
+- Effort: S (delete) or M (fix and integrate)
+- The vulnerable `strings.Contains` path is currently unreachable from production code (only its test references it), but it's a footgun: anyone wiring `ProjectScope` into a real handler regresses the security check that `models.IsInScope` already does correctly.
+- Recommended: **delete** `ProjectScope` and the `isURL` helper, and have callers use `models.Scope.IsInScope()` directly.
+
+**T0-3. Clean up `:memory:` literal directories**
+- Where: `internal/core/:memory:/`, `cmd/zerodaybuddy/:memory:/`
+- Effort: S
+- Find what opens SQLite with `":memory:"` as a filesystem path (likely a test or CLI default that misinterprets the SQLite in-memory sentinel) and patch it. Then `rm -rf` the stray directories. Add `:memory:/` to `.gitignore` as a belt-and-suspenders.
+- Why first: low cost, signals correctness, rules out a path-handling bug elsewhere.
+
+### Tier 1 — Stale and misleading (small effort, high trust gain)
+
+**T1-1. Update `CLAUDE.md` to match reality**
+- Where: `CLAUDE.md`
+- Effort: S
+- Remove the "scan service is currently stub" claim; document gitleaks/trivy scanners; document SARIF and GitHub report modules; explicitly note that the web UI is not yet wired (so future Claude sessions don't assume it works).
+
+**T1-2. Refresh `TODO.md`**
+- Where: `TODO.md`
+- Effort: S
+- Remove items completed in Phases 1-4: signal handling, JWT secret generation, log level config, error handling standardization.
+- Move "Future Considerations" (ML, plugin system, alt DB backends) to `docs/future-ideas.md` or delete — they currently muddy the priority signal.
+
+**T1-3. Populate `CHANGELOG.md` `[Unreleased]`**
+- Where: `CHANGELOG.md`
+- Effort: S
+- Document Phases 1-4 modernization, recent issue fixes (#9, #12, #13, #14), scanner additions (gitleaks, trivy), SARIF support, GitHub report integration.
+
+**T1-4. Archive scratch and one-off files**
+- Where: repo root
+- Effort: S
+- Move to `docs/archive/` or delete: `scratch-gap-analysis.md`, `scratch-issues-progress.md`, `scratch-research-notes.md`, `scratch-research-2026.md`, `scratch-security-standards-research.md`, `HACKERONE_HACKER_LIMITATIONS.md`, `ZERODAYBUDDY_TEST_REPORT.md`, `create_manual_project.sql`, `test_server.py`.
+- Note: extract any still-actionable items into this punch list before archiving (already done for the major ones).
+
+### Tier 2 — Finish the iceberg (high leverage; built code currently dark)
+
+**T2-1. Wire the web router**
+- Where: `internal/web/server.go`
+- Effort: L (significant, but every line of dependency code already exists)
+- Replace the stub mux with a real router (chi or net/http with method routing) that:
+  - Registers `AuthHandler` (`internal/web/handlers/auth.go`) at `/api/auth/login`, `/api/auth/refresh`, `/api/auth/logout`.
+  - Applies middleware in the correct order: `RecoverPanic` → `SecurityHeaders` → `RateLimit` → `Auth` (per-route).
+  - Serves static assets from `web/static/`.
+  - Loads templates from `web/templates/` via `html/template`.
+- Wire dependencies through `App.RegisterService` calls in `internal/core/app.go:Initialize`.
+- Why this tier: turns the project from "CLI with placeholder web stub" into "CLI + functional web app". Single biggest user-visible improvement per hour spent.
+- Depends on: nothing.
+- Blocks: T2-2, T2-3, all Tier 4 web work.
+
+**T2-2. Add data-model REST handlers**
+- Where: new files under `internal/web/handlers/` (projects.go, hosts.go, endpoints.go, findings.go, tasks.go)
+- Effort: M-L
+- Minimum: GET (list, by-id), POST (create), DELETE for projects + read-only GETs for hosts/endpoints/findings/tasks. Mutation endpoints for findings (status change, severity override).
+- Wire via T2-1's router.
+- Depends on: T2-1.
+
+**T2-3. Templates and static-asset pipeline**
+- Where: `internal/web/server.go`, `web/templates/`, `web/static/`
+- Effort: M
+- Wire `html/template` parsing at startup; serve `/static/*` from `web/static/`; render dashboard, project list, project detail, scan-detail, findings pages.
+- Inspect what templates are currently in `web/templates/` and align with what handlers need.
+- Depends on: T2-1.
+
+### Tier 3 — Surface expansion (new capability; addresses real-user blockers)
+
+**T3-1. Manual project mode**
+- Where: `pkg/validation/validation.go`, `internal/core/app.go`, `cmd/zerodaybuddy/main.go`
+- Effort: M
+- Add a `"manual"` platform type. New CLI: `zerodaybuddy project create --manual --name X --scope-file scope.{yaml,json}`.
+- `App.CreateProject` factored to accept either `(platform, programHandle)` or `(scopeDoc)`.
+- Why valuable: directly unblocks individual hackers (who can't use HackerOne org-tier API) and arbitrary security work. Addresses concerns documented in `HACKERONE_HACKER_LIMITATIONS.md` and `ZERODAYBUDDY_TEST_REPORT.md`. Materially expands the addressable user base.
+- Depends on: nothing structurally; benefits from T2-2 if web-based project creation is wanted.
+
+**T3-2. Scope file schema**
+- Where: new `pkg/models/scopefile.go` + example in `examples/scope.yaml`
+- Effort: S-M
+- Define a YAML/JSON schema covering: `in_scope[]`, `out_of_scope[]`, asset types (`url`, `domain`, `ip`, `cidr`, `wildcard`, `mobile-android`, `mobile-ios`, `code`, `executable`, `hardware`, `other`).
+- Aligns with HackerOne and Bugcrowd asset taxonomies (per `scratch-security-standards-research.md`).
+- Depends on: T3-1.
+
+**T3-3. HackerOne hacker-account workflow clarification**
+- Where: `internal/platform/hackerone.go`, `cmd/zerodaybuddy/main.go`
+- Effort: M
+- Detect when a token has hacker-tier (not org-tier) permissions; emit a clear error with a pointer to manual mode (T3-1). Optionally: support hacker-side endpoints where they exist (e.g. `/v1/hackers/me`).
+- Mostly clarification + error-message work; not a full alternate API client.
+- Depends on: T3-1 (so the error message can recommend manual mode).
+
+### Tier 4 — Polish / nice-to-have (only after Tier 0-3)
+
+- **T4-1.** Verify pagination across all platform clients post-#9 merge.
+- **T4-2.** Real-time scan progress via SSE or WebSocket (depends on T2-1).
+- **T4-3.** Scan scheduling (cron-style).
+- **T4-4.** Findings export to HackerOne/Bugcrowd report submission formats (depends on T3-1, T3-2).
+- **T4-5.** Scan-over-time comparison view (depends on T2-2).
+
+---
+
+## 4. Out of Scope
+
+- Machine-learning vulnerability prediction (TODO.md "Future Considerations").
+- Plugin/extension system (TODO.md "Future Considerations").
+- Alternate DB backends — SQLite is sufficient for the use case; rip out the TODO line.
+- Multi-user RBAC — auth tables exist but no concrete demand; revisit when there's a second user.
+- Slack/Discord notifications, JIRA/GitHub issue tracker integration.
+- Two-factor authentication.
+- Bug bounty program for the tool itself.
+
+---
+
+## 5. Open Questions
+
+These shape Tier 2 and Tier 3 priority. Worth answering before pulling Tier 2 work off the top.
+
+1. **Is the web UI actually a goal?** If the project has effectively pivoted to CLI-first, Tier 2 is wasted leverage. If not, Tier 2 is the biggest win per hour.
+2. **Are there active users besides the maintainer?** Affects whether T1-* cleanups need migration notes and whether T3-* gets prioritized over polish.
+3. **Is "individual hacker" a real target persona?** If yes, T3-1 jumps in priority above some Tier 2 items. If no, T3-* drops.
+4. **Is there a release cadence?** Affects whether T1-3 (CHANGELOG) is decorative or load-bearing.
+
+---
+
+## 6. Dependency Graph (compact)
+
+```
+T0-1 ─┐
+T0-2 ─┼── independent ──> green test suite
+T0-3 ─┘
+
+T1-1, T1-2, T1-3, T1-4 ─── all independent
+
+T2-1 ──┬─> T2-2 ──┬─> T4-2, T4-5
+       └─> T2-3 ──┘
+
+T3-1 ──┬─> T3-2 ──> T4-4
+       └─> T3-3
+```
+
+Tier 0 + Tier 1 can land in parallel with no blockers. Tier 2 has internal sequencing (T2-1 first). Tier 3 has internal sequencing (T3-1 first).
+
+---
+
+## 7. Suggested Sequence (correctness-first)
+
+| Window | Items | Outcome |
+|---|---|---|
+| Session 1 | T0-1, T0-2, T0-3 | Test suite fully green; dead code removed; cosmetic dirs gone |
+| Session 2 | T1-1, T1-2, T1-3, T1-4 | Docs match reality; repo root clean; trust-in-repo restored |
+| Sessions 3-5 | T2-1 | Web router wired; auth flow live; static assets served |
+| Sessions 6-8 | T2-2, T2-3 | Data-model handlers + templates live; web UI usable |
+| Sessions 9-10 | T3-1, T3-2 | Manual project mode + scope file schema |
+| Session 11 | T3-3 | Hacker-account UX clarification |
+| Future | Tier 4 as demand surfaces |
+
+---
+
+## 8. Success Criteria
+
+The punch list is "done" when:
+
+- `go test ./...` runs to completion with zero build failures (T0-1).
+- `grep -rn "strings.Contains.*Value" pkg/` returns no scope-check results (T0-2).
+- `find . -path "*/:memory:*"` returns nothing (T0-3).
+- `CLAUDE.md`, `TODO.md`, `CHANGELOG.md` accurately describe the codebase as it actually exists (T1-*).
+- `curl http://localhost:8080/api/auth/login` does something other than 404 (T2-1).
+- `zerodaybuddy project create --manual --name foo --scope-file ex.yaml` produces a working project (T3-1).
+
+Each tier's success criteria should be its own verification gate before moving to the next.

--- a/docs/plans/2026-05-10-001-fix-tier-0-correctness-plan.md
+++ b/docs/plans/2026-05-10-001-fix-tier-0-correctness-plan.md
@@ -1,0 +1,220 @@
+---
+title: "fix: Tier 0 correctness — complete validation security fix and clean up :memory: test bug"
+date: 2026-05-10
+type: fix
+depth: lightweight
+status: active
+origin: docs/brainstorms/codebase-punch-list-requirements.md
+related_units: U1, U2
+---
+
+# Tier 0 Correctness Plan
+
+## Summary
+
+Land all three Tier 0 punch-list items (T0-1, T0-2, T0-3 from the origin brainstorm) in a single session that ends with `go test ./...` green and no `:memory:` directories on disk.
+
+The plan collapses what the brainstorm framed as three independent items into **two implementation units**:
+
+| Unit | Origin items | Why grouped |
+|---|---|---|
+| U1 | T0-1 + T0-2 | The broken test file *is* the in-progress security fix for the strings.Contains scope-bypass. Implementing the missing functions both unblocks the build and lands the security fix — they cannot meaningfully be separated. |
+| U2 | T0-3 | Fix the test config bug that creates literal `:memory:/` directories on disk. Independent root cause (`internal/core/app_test.go:18`), independent file surface. |
+
+---
+
+## Problem Frame
+
+Three independent correctness defects identified in the brainstorm-time audit:
+
+1. **`pkg/validation/project_test.go` fails to build** — the (untracked) test file references `matchesDomain` and `extractHost`, neither of which exists in the package. Result: `go test ./...` fails with `undefined:` errors before any assertions run, blocking CI signal for the whole repo.
+
+2. **`pkg/validation/project.go:48` `ProjectScope`** uses `strings.Contains(target, asset.Value)` for in-scope checks. This is exploitable in principle: a target of `evil-example.com` matches an in-scope asset of `example.com`. Currently *unreachable* from production code (`validation.ProjectScope` has zero non-test callers — confirmed by `grep -rn "validation\.ProjectScope\|\.ProjectScope("`), but the planned web-handler work in Tier 2 of the brainstorm will need exactly this kind of pre-fetch URL-vs-scope validation, so quietly deleting the function leaves a hole that the next handler implementer will refill from scratch.
+
+3. **`internal/core/:memory:/` and `cmd/zerodaybuddy/:memory:/` directories** exist on disk because `internal/core/app_test.go:18` sets `DataDir: ":memory:"`, treating it as a SQLite in-memory sentinel. But `internal/storage/store.go:90 NewStore()` does `os.MkdirAll(dataDir, 0700)` first, then `filepath.Join(dataDir, "zerodaybuddy.db")` — so a literal directory `:memory:/` gets created at whatever cwd the test runs from, and the database is opened at `:memory:/zerodaybuddy.db` (a real on-disk file, not in-memory). Cosmetic but signals a quietly-failing test contract.
+
+---
+
+## Requirements Trace
+
+From `docs/brainstorms/codebase-punch-list-requirements.md`:
+
+- **T0-1** (Fix `pkg/validation/project_test.go` build break) → **U1**
+- **T0-2** (Resolve duplicate scope-checking implementations) → **U1** (with brainstorm-recommendation reversal — see Key Technical Decisions D1)
+- **T0-3** (Clean up `:memory:` literal directories) → **U2**
+
+Tier 0 success criterion from origin:
+
+> `go test ./...` runs to completion with zero build failures (T0-1)
+> `grep -rn "strings.Contains.*Value" pkg/` returns no scope-check results (T0-2)
+> `find . -path "*/:memory:*"` returns nothing (T0-3)
+
+All three are addressed by U1 + U2. See **Verification** below for the explicit gate.
+
+---
+
+## Key Technical Decisions
+
+### D1. Complete the in-progress security fix instead of deleting `ProjectScope`
+
+**Reverses the brainstorm's "delete it" recommendation.** Reading `pkg/validation/project_test.go` revealed the test file is not abandoned cruft — it is a deliberate, comprehensive security fix in progress:
+
+- Tests cover the exact boundary bypass the original code allowed: `evil-example.com / example.com → false`, `notexample.com / example.com → false`, `example.com.evil.com / example.com → false`.
+- Tests cover wildcard patterns (`*.example.com`).
+- Tests cover the URL parsing path (`https://example.com:8443/path` → `example.com`).
+- Tests cover the case where `ProjectScope` itself rejects bypass attempts at the public API.
+
+Deleting `ProjectScope` and these tests would discard work and leave the next contributor (likely Tier 2's web handlers) to re-derive the same logic from scratch. Completing the fix is a smaller delta and produces a reusable, well-tested validation helper for future handler work.
+
+**Boundary with `models.Scope.IsInScope`.** The two functions serve different layers and remain both useful:
+
+| Function | Inputs | Caller layer | Use case |
+|---|---|---|---|
+| `models.Scope.IsInScope(assetType, value)` | already-loaded `Scope`, asset value | service layer (already has Project) | "is this URL in this in-memory project's scope?" |
+| `validation.ProjectScope(ctx, store, projectName, target)` | name, target, store handle | handler / CLI layer (only has user input) | "given a project name, look it up and validate the user-provided target before doing real work" |
+
+### D2. `:memory:` fix is a test-side correction, not a storage-layer behavior change
+
+**Origin of the bug:** `internal/core/app_test.go:18 getTestConfig()` returns `DataDir: ":memory:"` — the developer assumed `:memory:` would route to SQLite's in-memory mode. But `internal/storage/store.go:90 NewStore()` treats `dataDir` as a filesystem path and does `os.MkdirAll(dataDir, 0700)` first.
+
+**Fix chosen:** Change `getTestConfig()` to take `*testing.T` and use `t.TempDir()` for `DataDir`. This is the minimal-correct change and matches the pattern already used by `cmd/zerodaybuddy/test_helpers.go:createTestApp` (which uses `os.MkdirTemp("", "zerodaybuddy-test-*")`).
+
+**Considered and deferred:** Adding defensive sentinel handling in `storage.NewStore` (detect `":memory:"` and route to `sqlx.Connect("sqlite", ":memory:")` directly). This would be a *better* contract — SQLite users reasonably expect that semantics — but it's a production-code behavior change beyond Tier 0 correctness scope. Routed to "Deferred to Follow-Up Work" below.
+
+### D3. Single batched commit boundary
+
+Both units are small, low-risk, and verified by the same `go test ./...` gate. Land both in one PR/commit (or two atomic commits within the same PR) to keep the Tier 0 punch-list closure visible as one unit of work.
+
+---
+
+## Implementation Units
+
+### U1. Complete the validation security fix
+
+**Goal:** Implement `matchesDomain` and `extractHost` in `pkg/validation/project.go`, refactor `ProjectScope` to use them, ensure `pkg/validation` test build passes and all tests in `project_test.go` pass.
+
+**Requirements:** T0-1, T0-2 from origin.
+
+**Dependencies:** None.
+
+**Files:**
+- `pkg/validation/project.go` (modify): add `matchesDomain(targetHost, scopeDomain string) bool` and `extractHost(rawURL string) string`; refactor `ProjectScope` to call them
+- `pkg/validation/project_test.go` (already exists, untracked): add to git; do not modify the test cases (they are the spec)
+
+**Approach:**
+- `extractHost(rawURL)` parses `rawURL` via `net/url.Parse` and returns the hostname portion (port-stripped). Returns empty string when parse fails or host is empty. This matches the `TestExtractHost` cases including `"not a url" → ""` (since `url.Parse` of an unstructured string yields no host).
+- `matchesDomain(targetHost, scopeDomain)` performs case-insensitive matching with three accept paths: (1) exact match (`targetHost == scopeDomain`); (2) wildcard scope (`*.example.com`) matching `example.com` and any subdomain; (3) plain scope domain matching subdomains via dot-anchored suffix check (`strings.HasSuffix(target, "."+scope)`). Empty `targetHost` or empty `scopeDomain` returns false.
+- The dot-anchored suffix check is the security-critical detail: `strings.HasSuffix("evil-example.com", "example.com")` is true, but `strings.HasSuffix("evil-example.com", ".example.com")` is false. The test cases in `TestMatchesDomain` and `TestProjectScope_DomainBoundary` enforce this boundary.
+- `ProjectScope` is refactored to: (a) load the project as before; (b) for URL targets, `extractHost` then walk in-scope assets calling `matchesDomain` for `Domain` and `URL` types (the URL case `extractHost`s the asset value first); (c) for non-URL targets, walk in-scope assets matching exactly. Replace the existing `strings.Contains` line.
+- Keep `ProjectExists` and `isURL` unchanged — both have passing tests.
+
+**Patterns to follow:**
+- The fix mirrors the pattern already established in `pkg/models/models.go:296 matchAsset()` and `pkg/models/models.go:338 isSubdomain()`. Worth scanning that file for conformance, but do *not* import models functions into validation — the layering should stay one-way (validation is a leaf, models is a dependency of validation, not the other way).
+- Error messages on failed scope checks should mirror the existing format (`"target '%s' is not in project scope"`).
+
+**Test scenarios** (the test file already enumerates these; they are the specification):
+- **`TestMatchesDomain`:** exact, case-insensitive, subdomain, deep subdomain, boundary-bypass blocked (`evil-example.com`, `notexample.com`, `example.com.evil.com`), wildcard exact and subdomain matches, wildcard rejecting unrelated and boundary-bypass attempts, empty target, empty scope, completely unrelated domain.
+- **`TestExtractHost`:** simple URL, URL with port (port stripped), URL with path, URL with subdomain, invalid URL (returns empty string).
+- **`TestProjectScope_DomainBoundary`:** exact domain match in URL, subdomain match in URL, exact URL-asset match; rejects boundary bypass (`evil-example.com`), prefix bypass (`notexample.com`), unrelated domain.
+- **`TestProjectScope_NonURL`:** exact non-URL match, no match.
+- **`TestIsURL`:** https/http accepted; bare domain, ftp, short string, empty rejected.
+- **`TestProjectExists`:** existing project ok; not-found error; invalid name (empty, special chars) rejected.
+
+**Verification:**
+- `go build ./pkg/validation/...` succeeds.
+- `go test ./pkg/validation/... -count=1 -v` passes all subtests.
+- `grep -n "strings.Contains" pkg/validation/project.go` returns nothing.
+
+---
+
+### U2. Fix `:memory:` test config bug and clean up stray directories
+
+**Goal:** Eliminate the literal `:memory:/` directories that get created when `internal/core` tests run, by fixing the test config to use `t.TempDir()` instead of the misinterpreted SQLite sentinel.
+
+**Requirements:** T0-3 from origin.
+
+**Dependencies:** None.
+
+**Files:**
+- `internal/core/app_test.go` (modify): change `getTestConfig()` signature to `func getTestConfig(t *testing.T) *config.Config`; replace `DataDir: ":memory:"` with `DataDir: t.TempDir()`; update all call sites in this file to pass `t`
+- `.gitignore` (modify): add `:memory:/` entry as defense-in-depth so any future regression doesn't pollute commits
+- `internal/core/:memory:/` (delete): `rm -rf` the stray directory and its contents (`zerodaybuddy.db`, `.db-shm`, `.db-wal`)
+- `cmd/zerodaybuddy/:memory:/` (delete): `rm -rf` the stray empty directory
+
+**Approach:**
+- `getTestConfig` currently has no `*testing.T` parameter. Adding it is a mechanical signature change — every caller in `internal/core/app_test.go` already has `t` in scope (they're `func TestXxx(t *testing.T)`). Update all `cfg := getTestConfig()` call sites to `cfg := getTestConfig(t)`.
+- Three call sites in the same file already override `cfg.DataDir = t.TempDir()` after calling `getTestConfig()` (lines 196, 220, 240). After the fix they can keep that override harmlessly — `t.TempDir()` in `getTestConfig` and again at the call site just produces two temp dirs, only the second one is used. Leave the override calls in place to preserve test intent (the override-callers explicitly want their own scoped tempdir for the body of the test).
+- `cmd/zerodaybuddy/test_helpers.go:createTestApp` already uses `os.MkdirTemp` correctly. No changes needed there. The stray `cmd/zerodaybuddy/:memory:/` directory was created earlier by a different code path (now historical) and is empty — it just needs deletion.
+- The `.gitignore` addition (`:memory:/`) prevents future accidental commits if this regression returns. It's a one-line defensive measure.
+
+**Patterns to follow:**
+- `cmd/zerodaybuddy/test_helpers.go:12 createTestApp(t *testing.T)` is the established pattern for test helpers that need temp data dirs.
+- `internal/auth/service_test.go:16 sqlx.Connect("sqlite", ":memory:")` is the *correct* way to use SQLite's in-memory sentinel — directly as a DSN, not via the `DataDir → MkdirAll → filepath.Join` path.
+
+**Test scenarios:**
+- After the change, `go test ./internal/core/... -count=1` runs without creating any `:memory:` directories anywhere on disk.
+- All existing tests in `internal/core/app_test.go` still pass.
+- `go test ./...` does not create new `:memory:/` artifacts (verified by `find . -path "*/:memory:*"` after a full test run).
+
+Test expectation: none for the `.gitignore` change (configuration only, no behavior change).
+
+**Verification:**
+- `go test ./internal/core/... -count=1` passes.
+- `find /Users/nconsolo/claude-code/zerodaybuddy -path "*/:memory:*"` returns nothing.
+- `git status` shows no untracked `:memory:` directories.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- Implementing `matchesDomain` and `extractHost` in `pkg/validation/project.go`.
+- Refactoring `ProjectScope` to use the new functions.
+- Adding `pkg/validation/project_test.go` to git (it currently shows as untracked).
+- Fixing `internal/core/app_test.go:getTestConfig()` to take `*testing.T` and use `t.TempDir()`.
+- Deleting the stray `:memory:/` directories.
+- Adding `:memory:/` to `.gitignore`.
+
+### Deferred to Follow-Up Work
+
+- **Defensive `:memory:` sentinel in `storage.NewStore`.** Detect when `dataDir == ":memory:"` and route to `sqlx.Connect("sqlite", ":memory:")` directly without `MkdirAll`. Better contract, matches SQLite convention, but is a production-code behavior change beyond Tier 0 scope. Worth a separate plan if/when an in-memory test mode for the storage layer is genuinely needed.
+- **Wiring `validation.ProjectScope` into production callers.** Currently dead code. Will become live when Tier 2 web-handler work (T2-1, T2-2 in the brainstorm) lands and accepts user-submitted URLs. That's a separate plan.
+- **Auditing for other `:memory:`-style magic-string assumptions.** The `:memory:` bug is a single instance; there might be other places where developers assumed library sentinels work through wrapping layers. Out of scope for Tier 0; could become a Tier 1 hygiene pass.
+
+### Not chasing
+
+- All Tier 1, 2, 3, 4 items from the origin brainstorm — those are sequenced for later sessions per the suggested-sequence table in `docs/brainstorms/codebase-punch-list-requirements.md`.
+- Refactoring `models.IsInScope` or `models.matchAsset` — they pass their tests and serve a different layer (see D1). Out of scope.
+
+---
+
+## Open Questions
+
+None blocking. The reversal in D1 is a strong recommendation that the user already implicitly endorsed by ranking correctness-first; if they disagree, U1 can be re-scoped to "delete `ProjectScope` and its test file" without changing U2.
+
+---
+
+## Verification Gate (end-of-plan)
+
+The plan is complete when **all** of the following return clean:
+
+```text
+1. go build ./...                                                      # from repo root
+2. go test ./... -count=1                                              # all packages, all tests
+3. grep -rn "strings.Contains" pkg/validation/project.go               # → empty
+4. find . -path "*/:memory:*" -not -path "*/.git/*"                    # → empty
+5. git diff --stat                                                      # touches expected files only
+```
+
+If any of (1)-(4) fail, the corresponding unit is incomplete. Step (5) is a sanity check that the diff stays scoped.
+
+---
+
+## Suggested Commit Boundary
+
+Two atomic commits, both in the same PR:
+
+1. `fix(validation): complete domain-boundary scope check (T0-1, T0-2)` — covers U1
+2. `fix(test): use t.TempDir() in getTestConfig to stop creating :memory: dirs (T0-3)` — covers U2
+
+Or one squashed commit if the PR is short-lived. Either is fine — D3 just requires that both units land together so Tier 0 closes as a single unit of progress against the brainstorm.

--- a/internal/core/app_test.go
+++ b/internal/core/app_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getTestConfig() *config.Config {
+func getTestConfig(t *testing.T) *config.Config {
+	t.Helper()
 	return &config.Config{
-		DataDir: ":memory:",
+		DataDir: t.TempDir(),
 		LogDir:  "",
 		Logging: config.LoggingConfig{
 			Level:        "info",
@@ -43,7 +44,7 @@ func getTestConfig() *config.Config {
 }
 
 func TestNewApp(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	assert.NotNil(t, app)
@@ -54,7 +55,7 @@ func TestNewApp(t *testing.T) {
 }
 
 func TestAppInitialize(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -73,7 +74,7 @@ func TestAppInitialize(t *testing.T) {
 }
 
 func TestAppInitializeWithoutJWTSecret(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	cfg.WebServer.JWTSecret = ""
 	cfg.WebServer.JWTIssuer = ""
 	
@@ -86,7 +87,7 @@ func TestAppInitializeWithoutJWTSecret(t *testing.T) {
 }
 
 func TestGetAuthService(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -99,7 +100,7 @@ func TestGetAuthService(t *testing.T) {
 }
 
 func TestGetConfig(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	returnedCfg := app.GetConfig()
@@ -107,7 +108,7 @@ func TestGetConfig(t *testing.T) {
 }
 
 func TestListProgramsUnknownPlatform(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -120,7 +121,7 @@ func TestListProgramsUnknownPlatform(t *testing.T) {
 }
 
 func TestCreateProjectUnknownPlatform(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -133,7 +134,7 @@ func TestCreateProjectUnknownPlatform(t *testing.T) {
 }
 
 func TestListProjects(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -146,7 +147,7 @@ func TestListProjects(t *testing.T) {
 }
 
 func TestRunReconProjectNotFound(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -166,7 +167,7 @@ func TestRunReconProjectNotFound(t *testing.T) {
 }
 
 func TestRunScanProjectNotFound(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -179,7 +180,7 @@ func TestRunScanProjectNotFound(t *testing.T) {
 }
 
 func TestGenerateReportProjectNotFound(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	ctx := context.Background()
@@ -192,7 +193,7 @@ func TestGenerateReportProjectNotFound(t *testing.T) {
 }
 
 func TestServeWithCustomHostPort(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	cfg.DataDir = t.TempDir()
 	app := NewApp(cfg)
 
@@ -216,7 +217,7 @@ func TestServeWithCustomHostPort(t *testing.T) {
 }
 
 func TestServeWithoutInit(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	cfg.DataDir = t.TempDir()
 	app := NewApp(cfg)
 
@@ -233,7 +234,7 @@ func TestServeWithoutInit(t *testing.T) {
 }
 
 func TestRunReconWithoutInit(t *testing.T) {
-	cfg := getTestConfig()
+	cfg := getTestConfig(t)
 	app := NewApp(cfg)
 	
 	// Create a fresh store instance for this test

--- a/pkg/validation/project.go
+++ b/pkg/validation/project.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/perplext/zerodaybuddy/pkg/models"
@@ -15,56 +16,101 @@ type ProjectStore interface {
 
 // ProjectExists validates that a project exists in the database
 func ProjectExists(ctx context.Context, store ProjectStore, projectName string) error {
-	// First validate the project name format
 	if err := ProjectName(projectName); err != nil {
 		return err
 	}
-	
-	// Check if project exists
-	_, err := store.GetProjectByName(ctx, projectName)
-	if err != nil {
+
+	if _, err := store.GetProjectByName(ctx, projectName); err != nil {
 		return fmt.Errorf("project '%s' not found", projectName)
 	}
-	
+
 	return nil
 }
 
-// ProjectScope validates that a target is within the project's scope
+// ProjectScope validates that a target is within the project's scope.
+// For URL targets, the target's host is extracted and matched against in-scope
+// Domain and URL assets using dot-anchored matching to prevent boundary-bypass
+// attacks (e.g., "evil-example.com" must not match in-scope "example.com").
 func ProjectScope(ctx context.Context, store ProjectStore, projectName string, target string) error {
-	// Get the project
 	project, err := store.GetProjectByName(ctx, projectName)
 	if err != nil {
 		return fmt.Errorf("project '%s' not found", projectName)
 	}
-	
-	// Check if target is in scope
-	// For URLs, extract the domain
+
 	if isURL(target) {
-		// Parse URL and check domain against scope
-		// This is a simplified check - in production, you'd want more sophisticated scope checking
+		targetHost := extractHost(target)
+		if targetHost == "" {
+			return fmt.Errorf("target '%s' is not in project scope", target)
+		}
 		for _, asset := range project.Scope.InScope {
-			if asset.Type == models.AssetTypeDomain || asset.Type == models.AssetTypeURL {
-				// Simple contains check - in production, use proper domain matching
-				if strings.Contains(target, asset.Value) {
+			switch asset.Type {
+			case models.AssetTypeDomain:
+				if matchesDomain(targetHost, asset.Value) {
+					return nil
+				}
+			case models.AssetTypeURL:
+				assetHost := extractHost(asset.Value)
+				if assetHost != "" && matchesDomain(targetHost, assetHost) {
 					return nil
 				}
 			}
 		}
 		return fmt.Errorf("target '%s' is not in project scope", target)
 	}
-	
-	// For non-URLs, check direct match
+
 	for _, asset := range project.Scope.InScope {
 		if asset.Value == target {
 			return nil
 		}
 	}
-	
+
 	return fmt.Errorf("target '%s' is not in project scope", target)
 }
 
-// Helper function to check if string is URL
-func isURL(s string) bool {
-	return len(s) > 7 && (s[:7] == "http://" || s[:8] == "https://")
+// matchesDomain reports whether targetHost matches scopeDomain using dot-anchored
+// boundary-safe rules. It accepts exact matches, subdomain matches, and wildcard
+// patterns of the form "*.example.com" (which match both "example.com" and any
+// subdomain of it). Comparisons are case-insensitive and trailing dots are stripped.
+//
+// The dot anchoring is the security-critical detail: matchesDomain("evil-example.com",
+// "example.com") returns false because the suffix check requires ".example.com",
+// not "example.com".
+func matchesDomain(targetHost, scopeDomain string) bool {
+	if targetHost == "" || scopeDomain == "" {
+		return false
+	}
+
+	target := strings.ToLower(strings.TrimSuffix(targetHost, "."))
+
+	if strings.HasPrefix(scopeDomain, "*.") {
+		parent := strings.ToLower(strings.TrimSuffix(scopeDomain[2:], "."))
+		if parent == "" {
+			return false
+		}
+		if target == parent {
+			return true
+		}
+		return strings.HasSuffix(target, "."+parent)
+	}
+
+	scope := strings.ToLower(strings.TrimSuffix(scopeDomain, "."))
+	if target == scope {
+		return true
+	}
+	return strings.HasSuffix(target, "."+scope)
 }
 
+// extractHost returns the hostname (port-stripped) from a URL string. Returns
+// the empty string when the input cannot be parsed as a URL with a host.
+func extractHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+// isURL reports whether s starts with an http:// or https:// scheme.
+func isURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}

--- a/pkg/validation/project_test.go
+++ b/pkg/validation/project_test.go
@@ -1,0 +1,223 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockProjectStore implements ProjectStore for testing
+type mockProjectStore struct {
+	project *models.Project
+	err     error
+}
+
+func (m *mockProjectStore) GetProjectByName(ctx context.Context, name string) (*models.Project, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.project, nil
+}
+
+func TestProjectExists(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+		store       *mockProjectStore
+		wantErr     bool
+	}{
+		{
+			"project exists",
+			"test-project",
+			&mockProjectStore{project: &models.Project{Name: "test-project"}},
+			false,
+		},
+		{
+			"project not found",
+			"nonexistent",
+			&mockProjectStore{err: fmt.Errorf("not found")},
+			true,
+		},
+		{
+			"invalid project name",
+			"",
+			&mockProjectStore{},
+			true,
+		},
+		{
+			"invalid project name special chars",
+			"test project!",
+			&mockProjectStore{},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ProjectExists(context.Background(), tt.store, tt.projectName)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMatchesDomain(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetHost  string
+		scopeDomain string
+		want        bool
+	}{
+		// Exact match
+		{"exact match", "example.com", "example.com", true},
+		{"case insensitive match", "Example.COM", "example.com", true},
+
+		// Subdomain matching
+		{"subdomain match", "sub.example.com", "example.com", true},
+		{"deep subdomain match", "a.b.c.example.com", "example.com", true},
+
+		// Domain boundary — the critical security fix
+		{"boundary bypass blocked", "evil-example.com", "example.com", false},
+		{"boundary bypass prefix blocked", "notexample.com", "example.com", false},
+		{"boundary bypass suffix blocked", "example.com.evil.com", "example.com", false},
+
+		// Wildcard matching
+		{"wildcard subdomain match", "sub.example.com", "*.example.com", true},
+		{"wildcard deep subdomain match", "a.b.example.com", "*.example.com", true},
+		{"wildcard base domain match", "example.com", "*.example.com", true},
+		{"wildcard blocks unrelated", "evil.com", "*.example.com", false},
+		{"wildcard boundary safe", "evil-example.com", "*.example.com", false},
+
+		// No match
+		{"completely different domain", "other.com", "example.com", false},
+		{"empty target", "", "example.com", false},
+		{"empty scope", "example.com", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesDomain(tt.targetHost, tt.scopeDomain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProjectScope_DomainBoundary(t *testing.T) {
+	project := &models.Project{
+		Name: "test-project",
+		Scope: models.Scope{
+			InScope: []models.Asset{
+				{Type: models.AssetTypeDomain, Value: "example.com"},
+				{Type: models.AssetTypeURL, Value: "https://api.target.io"},
+			},
+		},
+	}
+	store := &mockProjectStore{project: project}
+
+	tests := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		// Should match
+		{"exact domain in URL", "https://example.com/path", false},
+		{"subdomain in URL", "https://sub.example.com/api", false},
+		{"scope URL exact match", "https://api.target.io/v1", false},
+
+		// Should NOT match (bypass attempts)
+		{"boundary bypass", "https://evil-example.com/path", true},
+		{"prefix bypass", "https://notexample.com", true},
+		{"unrelated domain", "https://other.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ProjectScope(context.Background(), store, "test-project", tt.target)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestProjectScope_NonURL(t *testing.T) {
+	project := &models.Project{
+		Name: "test-project",
+		Scope: models.Scope{
+			InScope: []models.Asset{
+				{Type: models.AssetTypeDomain, Value: "example.com"},
+			},
+		},
+	}
+	store := &mockProjectStore{project: project}
+
+	tests := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		{"exact match", "example.com", false},
+		{"no match", "other.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ProjectScope(context.Background(), store, "test-project", tt.target)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExtractHost(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"simple URL", "https://example.com", "example.com"},
+		{"URL with port", "https://example.com:8443", "example.com"},
+		{"URL with path", "https://example.com/api/v1", "example.com"},
+		{"URL with subdomain", "https://sub.example.com", "sub.example.com"},
+		{"invalid URL", "not a url", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractHost(tt.url)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"https URL", "https://example.com", true},
+		{"http URL", "http://example.com", true},
+		{"not a URL", "example.com", false},
+		{"ftp URL", "ftp://example.com", false},
+		{"short string", "http", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isURL(tt.s))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes Tier 0 of the codebase punch list (`docs/brainstorms/codebase-punch-list-requirements.md`) — the correctness-first batch of fixes.

Three commits, two units of behavior change, zero scope creep:

- **Validation security fix (T0-1, T0-2):** completes the in-progress `pkg/validation/project.go` security fix. Implements `matchesDomain` and `extractHost`, refactors `ProjectScope` to use them. Replaces a `strings.Contains` boundary-bypass that would have allowed `evil-example.com` to match in-scope `example.com`. Also unblocks the broken `go test ./pkg/validation/...` build (the test file was untracked and referenced functions that didn't exist).
- **`:memory:` test bug fix (T0-3):** changes `internal/core/app_test.go:getTestConfig()` to take `*testing.T` and use `t.TempDir()` instead of the literal string `":memory:"`. Root cause: `internal/storage/store.go:NewStore` does `os.MkdirAll(dataDir)` first, so passing `":memory:"` as a SQLite sentinel created a literal `:memory:/` directory at test cwd. Adds `:memory:/` to `.gitignore` as defense-in-depth.
- **Docs:** captures the upstream brainstorm doc and the executable plan that produced this PR.

### Decision reversal documented in plan

The brainstorm originally recommended *deleting* `ProjectScope` as dead code. While reading the test file during planning, I found it was actually a deliberate in-progress security fix with comprehensive boundary-bypass test cases. The plan reverses to *complete* the fix — see `docs/plans/2026-05-10-001-fix-tier-0-correctness-plan.md` Key Technical Decision D1 for the full rationale.

### Verification gate (all 5 pass)

| Check | Result |
|---|---|
| `go build ./...` | ✅ clean |
| `go test ./... -count=1` | ✅ 20/20 packages green (was 19/20 with `pkg/validation` broken) |
| `grep -rn "strings.Contains" pkg/validation/project.go` | ✅ empty |
| `find . -path "*/:memory:*"` | ✅ empty |
| `git diff --stat` (vs base) | ✅ only expected files |

### What's deferred (out of scope for this PR)

- **Defensive `:memory:` sentinel handling in `storage.NewStore`** — would route the SQLite in-memory DSN correctly. Better contract, but a production-code behavior change beyond Tier 0.
- **Wiring `validation.ProjectScope` into production callers** — currently still dead code. Becomes live when Tier 2 web-handler work lands (separate plan).
- **Tiers 1-4** of the punch list — staged for follow-up sessions per the brainstorm's suggested sequence.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` all packages pass
- [x] `pkg/validation` test build fixed; 32 new sub-tests pass (boundary, wildcard, case-insensitivity, URL parsing)
- [x] No `:memory:/` directories regenerate after `go test ./internal/core/...`
- [x] Branch rebased onto fresh `origin/main`; PR contains only the 3 Tier 0 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project scope validation for URL targets with proper domain boundary enforcement and wildcard pattern matching.

* **Tests**
  * Enhanced test infrastructure to use isolated temporary directories.
  * Added comprehensive test coverage for project validation logic.

* **Documentation**
  * Added audit summary and prioritized backlog for codebase improvements.
  * Added detailed correctness plan for Tier 0 fixes.

* **Chores**
  * Updated `.gitignore` to exclude additional temporary and build artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/perplext/zerodaybuddy/pull/16)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->