### PR TITLE
fix(ci): build golangci-lint from source so it lints Go 1.25 code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
         # Pinned to last v1 — v2 is a config-format breaking change that
         # requires migrating .golangci.yml. See docs/plans/2026-05-10-002-*.
         version: v1.64.8
+        # Build golangci-lint from source using the runner's Go (1.25). The
+        # prebuilt v1.64.8 binary was compiled with Go 1.24 and v1 refuses
+        # to lint code targeting a newer Go than itself.
+        install-mode: goinstall
         args: --timeout=3m
 
   security:


### PR DESCRIPTION
## Summary

Hotfix for the chronic-red `lint` CI check that's been failing since PR #17 bumped go.mod to Go 1.25.

## What was wrong

PR #17's lint pinning to `v1.64.8` was correct, but the `golangci-lint-action@v6` defaults to `install-mode: binary`, which downloads the prebuilt v1.64.8 tarball. That binary was published built with Go 1.24, and golangci-lint v1.x refuses to lint code targeting a newer Go than itself:

```
can't load config: the Go language version (go1.24) used to build
golangci-lint is lower than the targeted Go version (1.25.0)
```

I missed this locally because my `go install golangci-lint@v1.64.8` built it with my local Go 1.26.2, which masked the version skew that CI hits with the prebuilt binary.

## What this PR does

One-line workflow tweak: add `install-mode: goinstall` to the lint step. CI now builds golangci-lint from source using its own Go 1.25, sidestepping the prebuilt-binary version skew.

Tradeoff: ~10 sec longer for the build vs ~3 sec download. Worth it for actually-green lint.

## Why not migrate to v2.x

v2.x is a config-format breaking change requiring `.golangci.yml` migration (the existing config errors with "unsupported version of the configuration"). That's a bigger plan worth doing deliberately, not as a hotfix.

## What this does NOT fix

`security` (govulncheck) is still red because the relevant Go stdlib CVE fixes are in `1.25.10` which hasn't shipped yet. That's an upstream Go release timing issue, not actionable from this repo. Will resolve naturally when 1.25.10 lands.

## Test plan

- [x] Verified locally: lint clean at v1.64.8 (built locally with Go 1.26.2; CI will build with Go 1.25)
- [ ] CI on this PR: `lint` should turn green for the first time since the Go bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)