### PR TITLE
feat(web): data-model REST handlers — projects, hosts, endpoints, findings, tasks

### DIFF
--- a/docs/plans/2026-05-10-004-feat-data-model-rest-handlers-plan.md
+++ b/docs/plans/2026-05-10-004-feat-data-model-rest-handlers-plan.md
@@ -1,0 +1,683 @@
+---
+title: "feat: Data-model REST handlers — projects, hosts, endpoints, findings, tasks"
+date: 2026-05-10
+type: feat
+depth: deep
+status: active
+origin: docs/brainstorms/codebase-punch-list-requirements.md
+related_units: U1, U2, U3, U4, U5, U6
+---
+
+# Data-Model REST Handlers (T2-2)
+
+## Summary
+
+Build the read/write HTTP API surface for the five core data entities — projects, hosts, endpoints, findings, tasks — on top of the router and middleware stack T2-1 (PR #19) established. Roughly 13 endpoints across 5 handler files, each registered via the existing `Server.publicChain` / `Server.authedChain` pipeline.
+
+The work is mostly mechanical: wrap existing `storage.Store` methods in HTTP handlers with role-scoped auth and consistent JSON shapes. The architectural decisions (URL hierarchy, role enforcement layer, response envelope) account for most of this plan's content; the per-handler implementation is convention-following.
+
+This unblocks T2-3 (templates pipeline / dashboard UI — needs data endpoints to render against) and T3-1 (manual project mode — needs the project create endpoint).
+
+---
+
+## Problem Frame
+
+`internal/web/server.go:buildRouter()` (post-PR #19) registers the six `AuthHandler` endpoints, the `/health` and `/` index routes, and `/static/*`. None of the application's domain entities — projects, hosts, endpoints, findings, tasks — are reachable via HTTP. The CLI is the only interface to the data; web users have no way to browse projects, monitor scan progress, or triage findings without dropping into SQL.
+
+`internal/storage.Store` already exposes the data interface this PR needs:
+
+| Entity | Available methods | T2-2 endpoints |
+|---|---|---|
+| Project | Create, Get, GetByName, Update, List, Delete | List, Get, Create, Delete |
+| Host | Create, Get, Update, List(byProject), Delete | List(byProject), Get |
+| Endpoint | Create, Get, Update, List(byHost), ListByProject, Delete | List(byProject), Get |
+| Finding | Create, Get, Update, List(byProject), Delete | List(byProject), Get, PATCH |
+| Task | Create, Get, Update, List(byProject), Delete | List(byProject), Get |
+| Report | Create, Get, List(byProject), Delete | (deferred — not in T2-2 scope) |
+
+`internal/auth.User` already carries `Role` (admin / user / readonly) and `HasPermission(requiredRole)`. `middleware.AuthMiddleware` populates the user on the request context. T2-2 doesn't need new auth machinery — just to use what exists.
+
+`web.Dependencies` (introduced in T2-1) currently holds `{AuthService, StaticDir}`. T2-2 adds a `Store storage.Store` field; `App.Initialize` wires `a.store` through.
+
+---
+
+## Requirements Trace
+
+From `docs/brainstorms/codebase-punch-list-requirements.md`:
+
+- **T2-2** Data-model REST handlers → **U1, U2, U3, U4, U5, U6**
+
+Origin success criterion: GET endpoints for projects/hosts/endpoints/findings/tasks return JSON; POST creates a project; DELETE removes a project; mutation endpoints for findings allow status change and severity override.
+
+After this PR: a logged-in user with a bearer token can list, fetch, create, and delete projects via JSON API; can browse the hosts/endpoints/findings/tasks discovered for any project; can triage findings by changing status or severity. The CLI continues to work unchanged.
+
+---
+
+## Key Technical Decisions
+
+### D1. Mix-mode REST URL shape (nested for parent-scoped lists, flat for by-id)
+
+The `storage.Store` signatures dictate the natural shape:
+
+- `ListHosts(ctx, projectID)` — entries are inherently project-scoped
+- `ListEndpoints(ctx, hostID)` and `ListEndpointsByProject(ctx, projectID)` — both shapes available
+- `ListFindings(ctx, projectID)`, `ListTasks(ctx, projectID)` — project-scoped
+- `Get*(ctx, id)` — IDs are UUIDs, globally unique
+
+Going with mix-mode:
+- **List under parent**: `GET /api/projects/{pid}/hosts`, `/findings`, `/tasks`, `/endpoints`
+- **Single by id**: `GET /api/hosts/{id}`, `/api/findings/{id}`, etc.
+- **Project root**: `GET /api/projects`, `POST /api/projects`, `GET /api/projects/{id}`, `DELETE /api/projects/{id}`
+
+Considered alternatives:
+- **Pure nested** (`/api/projects/{pid}/hosts/{hid}`) — verbose; requires loading parent on every single-entity request even though the host's ID alone is unique.
+- **Pure flat with query params** (`/api/hosts?project_id=X`) — less discoverable; query-param-as-required-arg is awkward; loses URL-as-document-identity.
+
+Mix-mode honors REST hierarchy where the data model has it, and goes flat where the storage layer does. This is the same shape GitHub's API uses (`/repos/{org}/{repo}/issues` for list, `/issues/{id}` for individual cross-repo lookup).
+
+### D2. Findings mutation as unified `PATCH /api/findings/{id}`
+
+Brainstorm calls for "status change, severity override". Two URL shapes considered:
+
+- **Sub-resource per field**: `PATCH /api/findings/{id}/status`, `PATCH /api/findings/{id}/severity`
+- **Unified PATCH with allow-listed fields**: `PATCH /api/findings/{id}` with body `{"status": "...", "severity": "..."}`
+
+Going with **unified PATCH**. Rationale:
+
+1. Atomicity — a triager who wants to mark a finding as "false-positive" AND "info severity" gets one round-trip and one audit entry.
+2. REST-idiomatic — PATCH is the canonical "update some fields" verb.
+3. Explicit allow-list at the handler — only `status` and `severity` are honored; other fields in the body are ignored. This prevents accidental escalation (e.g., "client tried to PATCH `cvss` but the handler doesn't allow it").
+4. Easy to extend — adding "assignee" later is a one-line allow-list change, not a new endpoint.
+
+Document the allow-list in the handler. Reject requests where the body is empty or contains only ignored fields with 400.
+
+### D3. Per-route role enforcement inline in handlers (not via middleware)
+
+`internal/web/middleware/auth.go` exposes `AuthMiddleware`, `RequireRole(role, logger)`, `RequireAuth`, `AdminOnly`, `UserOrAdmin`. Two patterns considered:
+
+- **Middleware ladder**: chain `AuthMiddleware → RequireRole(RoleAdmin)` for each admin-only route
+- **Inline check**: in the handler, call `middleware.GetUserFromContext(r.Context())` and check `user.HasPermission(auth.RoleAdmin)` directly
+
+Going with **inline in handlers**. Rationale:
+
+1. Most handlers need user context anyway (to log who did what, to scope writes); fetching the User then checking permission is one line.
+2. Middleware-per-permission means N route registrations × M roles = chain explosion.
+3. Inline lets handlers carry route-specific logic (e.g., "users can DELETE projects they created; admins can DELETE any") without a custom middleware per rule.
+4. The role check returns the same 403 response shape across all handlers — easy to add via the U2 helper.
+
+`AuthMiddleware` still wraps every authed route; per-route role checks happen inside the handler body.
+
+### D4. Per-handler `RegisterRoutes(mux, ...)` method called from `buildRouter`
+
+T2-1 registered all six auth routes inline in `buildRouter()`. With 13+ new routes, that approach makes `buildRouter` hundreds of lines and forces a single-file evolution.
+
+Going with: each handler file (`projects.go`, `hosts.go`, etc.) exposes a `RegisterRoutes(mux *http.ServeMux, public, authed []func(http.Handler) http.Handler)` method. `buildRouter` calls each handler's `RegisterRoutes` after constructing it.
+
+This:
+1. Keeps route definitions next to handler implementation (cohesion).
+2. Reduces `buildRouter` to a thin wiring file.
+3. Makes per-handler tests easy — instantiate the handler, call RegisterRoutes against an isolated mux, exercise.
+4. Mirrors the pattern from popular Go web frameworks (chi's `Routes()`, gin's group registration).
+
+### D5. Response helpers in a new `internal/web/handlers/response.go`
+
+T2-1's `AuthHandler` uses `http.Error(w, msg, status)` for errors and inline `json.NewEncoder(w).Encode(v)` for success. Across 13 endpoints, this becomes inconsistent — different error shapes, different status-code use. Adding three helpers prevents the drift:
+
+- `writeJSON(w, status int, v any)` — sets `Content-Type: application/json`, `WriteHeader(status)`, encodes; logs encode errors but continues
+- `writeError(w, status int, code string, msg string)` — wraps a structured error response: `{"error": {"code": "...", "message": "..."}}`
+- `decodeJSON(r, v any)` — wraps `json.NewDecoder(r.Body).Decode(v)` with the project's standard 1 MiB body limit (already enforced by `MaxBodySize` middleware) and returns a typed error suitable for `writeError`
+
+The auth handler keeps using its current pattern (no need to migrate it in this PR); new handlers consistently use the helpers. `writeError`'s structured shape is forward-compatible — clients can switch on `error.code` to render translated messages or distinguish "not found" from "permission denied" without parsing the message string.
+
+### D6. Pagination intentionally deferred
+
+`storage.Store` returns full slices with no offset/limit. Adding pagination requires either:
+
+- (a) Changing the interface to add `(offset, limit int)` to every List* method — invasive, breaks all existing callers (CLI, services).
+- (b) Fetching the full slice and slicing in the handler — works but wastes memory for large lists and doesn't actually reduce DB load.
+
+Neither is acceptable for v1. Pagination becomes its own plan (likely a Tier 4 polish item) when finding lists routinely exceed ~1000 entries. Until then, all-or-nothing list responses are acceptable for the expected scale (a project typically has dozens of hosts and hundreds of findings, not millions).
+
+Document this in the API: list responses include the full result set; paginate later.
+
+### D7. Reports deferred from T2-2
+
+Brainstorm T2-2 lists projects/hosts/endpoints/findings/tasks. Reports are different:
+
+- Different storage interface shape (no `UpdateReport`)
+- Generated artifacts, not raw data
+- Already have a `report.Service` with `CreateReport`, `GenerateMarkdown`, etc. — exposing them via REST means designing the generation-vs-fetch dichotomy
+
+Defer to a separate PR. Add as `Deferred to Follow-Up Work`.
+
+### D8. Hosts, endpoints, and tasks are read-only
+
+These entities are created by the recon and scan services running asynchronously, not by users. Exposing POST/PUT for them would either:
+- Allow users to inject fabricated data (security risk for triage)
+- Require a separate "manual host" model (scope expansion)
+
+Read-only is correct for v1. `DELETE /api/hosts/{id}` could be a future admin escape-hatch but isn't called for in the brainstorm.
+
+---
+
+## High-Level Technical Design
+
+This illustrates the intended structure and is directional guidance for review, not implementation specification.
+
+### URL surface
+
+```text
+                                              auth     role check
+GET    /api/projects                          authed   none (any user)
+POST   /api/projects                          authed   user|admin
+GET    /api/projects/{id}                     authed   none
+DELETE /api/projects/{id}                     authed   admin
+
+GET    /api/projects/{id}/hosts               authed   none
+GET    /api/hosts/{id}                        authed   none
+
+GET    /api/projects/{id}/endpoints           authed   none
+GET    /api/endpoints/{id}                    authed   none
+
+GET    /api/projects/{id}/findings            authed   none
+GET    /api/findings/{id}                     authed   none
+PATCH  /api/findings/{id}                     authed   user|admin
+
+GET    /api/projects/{id}/tasks               authed   none
+GET    /api/tasks/{id}                        authed   none
+```
+
+13 endpoints. ReadOnly users hit the GETs only; writes (POST/DELETE/PATCH) require user-or-admin role; project deletion is admin-only.
+
+### Handler dependency wiring
+
+```mermaid
+flowchart LR
+    App[App.Initialize] -->|Dependencies&#123;Store, AuthService, StaticDir&#125;| NewServer
+    NewServer -->|s.deps.Store| BR[buildRouter]
+    BR -->|store, logger| PH[ProjectsHandler]
+    BR -->|store, logger| HH[HostsHandler]
+    BR -->|store, logger| EH[EndpointsHandler]
+    BR -->|store, logger| FH[FindingsHandler]
+    BR -->|store, logger| TH[TasksHandler]
+    PH & HH & EH & FH & TH -->|RegisterRoutes mux, chains| Mux[mux]
+```
+
+### Response shape
+
+Success — bare entity for single, bare slice for list:
+
+```text
+GET /api/projects/abc-123  → 200 + {Project}
+GET /api/projects          → 200 + [{Project}, {Project}, ...]
+POST /api/projects         → 201 + {Project}
+DELETE /api/projects/abc   → 204 + (empty body)
+```
+
+Error — structured envelope:
+
+```text
+404 + {"error": {"code": "not_found", "message": "project abc not found"}}
+403 + {"error": {"code": "forbidden", "message": "admin role required"}}
+400 + {"error": {"code": "invalid_body", "message": "..."}}
+500 + {"error": {"code": "internal", "message": "internal server error"}}
+```
+
+---
+
+## Output Structure
+
+```text
+internal/web/handlers/
+├── auth.go            (existing, unchanged)
+├── auth_test.go       (existing, unchanged)
+├── response.go        (NEW — U2: writeJSON, writeError, decodeJSON)
+├── response_test.go   (NEW — U2 tests)
+├── projects.go        (NEW — U3: ProjectsHandler + RegisterRoutes)
+├── projects_test.go   (NEW — U3 tests)
+├── hosts.go           (NEW — U4: HostsHandler)
+├── hosts_test.go      (NEW — U4 tests)
+├── endpoints.go       (NEW — U4: EndpointsHandler)
+├── endpoints_test.go  (NEW — U4 tests)
+├── tasks.go           (NEW — U4: TasksHandler)
+├── tasks_test.go      (NEW — U4 tests)
+├── findings.go        (NEW — U5: FindingsHandler with PATCH)
+└── findings_test.go   (NEW — U5 tests)
+```
+
+`internal/web/server.go` gains a `Store` field on `Dependencies` (U1) and per-handler RegisterRoutes calls in `buildRouter` (U6).
+
+---
+
+## Implementation Units
+
+### U1. Add `Store` to `web.Dependencies`; thread `a.store` through `App.Initialize`
+
+**Goal:** Make the storage layer reachable from the web handlers via the existing typed dependency-injection pattern.
+
+**Requirements:** T2-2 foundational.
+
+**Dependencies:** None (relies on T2-1 patterns already in main).
+
+**Files:**
+- `internal/web/server.go` (modify): add `Store storage.Store` field to `Dependencies` struct; document
+- `internal/core/app.go` (modify): include `Store: a.store` in the `web.Dependencies` literal in `Initialize`
+- `internal/web/server_test.go` (modify): update any tests that need to construct Dependencies (`newTestServer` helper accepts nil Store; new helper `newTestServerWithStore(t, store)` may be added if tests need it for U6)
+
+**Approach:**
+- Mirror `AuthService`'s pattern: optional field, document that "when nil, data-model routes are not registered" (parallel to AuthService skip-when-nil).
+- `App.Initialize` already creates `a.store` before `a.webSvc = web.NewServer(...)` — just thread it through.
+- Same package layout — `internal/web/server.go` already imports `internal/auth`; add `internal/storage` import.
+
+**Patterns to follow:**
+- T2-1's `Dependencies.AuthService` (`internal/web/server.go`) shows the exact shape.
+- T2-1's `App.Initialize` Dependencies literal in `internal/core/app.go` is the wiring site.
+
+**Test scenarios:**
+- **Happy path**: `NewServer` with `Dependencies{Store: storeMock}` returns non-nil Server; `s.deps.Store` is the passed store.
+- **Edge case**: `Dependencies{}` (no Store) — Server constructs without panic; subsequent route registration in U6 will skip data routes (verified there).
+- **Integration**: `App.Initialize` passes `a.store` through; verified by an existing core test that calls Initialize and accesses `app.webSvc.deps.Store` (would need a small accessor or unexported field check).
+
+**Verification:**
+- `grep "Store storage.Store" internal/web/server.go` returns the new field.
+- `go test ./internal/web/... ./internal/core/...` green.
+
+---
+
+### U2. Response and request helpers (`writeJSON`, `writeError`, `decodeJSON`)
+
+**Goal:** Provide three small helpers in `internal/web/handlers/response.go` that the entity handlers (U3-U5) use uniformly. Standardizes JSON encoding, error envelope shape, and request-body decoding.
+
+**Requirements:** T2-2 foundational; consumed by U3-U5.
+
+**Dependencies:** None.
+
+**Files:**
+- `internal/web/handlers/response.go` (new)
+- `internal/web/handlers/response_test.go` (new)
+
+**Approach:**
+- `writeJSON(w http.ResponseWriter, status int, v any, logger *utils.Logger)` — sets `Content-Type: application/json; charset=utf-8`, calls `WriteHeader(status)`, encodes via `json.NewEncoder(w).Encode(v)`. On encode error: logs and continues (response is already partially written; nothing to recover).
+- `writeError(w http.ResponseWriter, status int, code string, msg string, logger *utils.Logger)` — wraps the structured error envelope `{"error": {"code": code, "message": msg}}` and delegates to `writeJSON`. Standard codes: `not_found`, `forbidden`, `invalid_body`, `invalid_field`, `conflict`, `internal`, `unauthorized` (auth handler uses plain `http.Error` for unauthorized; new handlers can use `writeError` for consistency in their own routes).
+- `decodeJSON(r *http.Request, v any)` — wraps `json.NewDecoder(r.Body).Decode(v)`. Returns the raw decode error on failure (handler decides whether to translate to 400 invalid_body or pass through). Caller is responsible for closing the body via the standard request lifecycle.
+- All three helpers take a logger so encode/decode errors can be logged centrally.
+
+**Patterns to follow:**
+- The encode-error logging pattern from T2-1's auth handler post-fix (PR #19): `if err := json.NewEncoder(w).Encode(...); err != nil { logger.Error(...) }`.
+- No external libraries — `encoding/json` is sufficient.
+
+**Test scenarios:**
+- **Happy path — writeJSON**: encoding a struct returns 200 + correct Content-Type + body matches expected JSON.
+- **Happy path — writeError**: returns the documented envelope shape with code and message; status code matches the passed value.
+- **Edge case — writeJSON with nil**: writes "null" JSON literal (standard `encoding/json` behavior); doesn't panic.
+- **Edge case — writeJSON with non-encodable type** (e.g., `chan int`): logs an error; the response status is already set (the WriteHeader happened before encoding tried), so the test asserts the status was written and an error was logged.
+- **Happy path — decodeJSON**: valid body decodes into the target struct.
+- **Error path — decodeJSON with invalid JSON**: returns a non-nil error; target struct unchanged.
+- **Error path — decodeJSON with empty body**: returns `io.EOF`; caller can detect.
+- **Error path — decodeJSON with extra fields**: by default, `encoding/json` ignores unknown fields. Document this; do not enable `DisallowUnknownFields()` (which would break clients sending forward-compat fields).
+
+**Verification:**
+- All test scenarios pass.
+- `grep -n "writeJSON\|writeError\|decodeJSON" internal/web/handlers/` shows the helpers exported and the tests covering them.
+
+---
+
+### U3. Projects handler — full CRUD
+
+**Goal:** Implement `ProjectsHandler` in `internal/web/handlers/projects.go` covering List, Get, Create, and Delete. Wire role enforcement inline via `auth.User.HasPermission`.
+
+**Requirements:** T2-2 (project CRUD).
+
+**Dependencies:** U1 (Store in Dependencies), U2 (response helpers).
+
+**Files:**
+- `internal/web/handlers/projects.go` (new)
+- `internal/web/handlers/projects_test.go` (new)
+
+**Approach:**
+
+Endpoints:
+
+| Method | Path | Behavior | Auth |
+|---|---|---|---|
+| `GET` | `/api/projects` | List all projects via `store.ListProjects(ctx)`; 200 + `[]Project` | any user |
+| `POST` | `/api/projects` | Decode body (Project shape minus server-set fields); validate; `store.CreateProject(ctx, p)`; 201 + Project | user or admin |
+| `GET` | `/api/projects/{id}` | `store.GetProject(ctx, id)`; 200 + Project, or 404 | any user |
+| `DELETE` | `/api/projects/{id}` | `store.DeleteProject(ctx, id)`; 204 | admin only |
+
+`ProjectsHandler` constructor: `NewProjectsHandler(store storage.Store, logger *utils.Logger) *ProjectsHandler`.
+
+Method `RegisterRoutes(mux *http.ServeMux, authedChain []func(http.Handler) http.Handler)`:
+- Wraps each handler method via `middleware.Chain(handlerFn, authedChain...)`
+- Registers with method+pattern: `mux.Handle("GET /api/projects", ...)`, etc.
+- Uses Go 1.22 path parameters: `r.PathValue("id")` to extract `{id}`
+
+Inside Create / Delete handlers:
+1. Pull `user := middleware.GetUserFromContext(r.Context())`.
+2. Check `user.HasPermission(auth.RoleUser)` (Create) or `auth.RoleAdmin` (Delete).
+3. If insufficient: `writeError(w, 403, "forbidden", "...")`.
+4. Otherwise proceed.
+
+Validate inputs in Create:
+- `Name` non-empty and matches existing `validation.ProjectName` rules.
+- `Platform` is "hackerone", "bugcrowd", "immunefi", or "manual" (validation.go has a list — reuse).
+- `Scope` is parseable but otherwise pass-through; comprehensive scope validation is T3-1/T3-2 territory.
+- Server-set fields (`ID`, `CreatedAt`, `UpdatedAt`) ignored from request body; the storage layer assigns IDs via `uuid.New().String()` (existing pattern in `internal/storage/store.go:CreateProject`).
+
+For Delete: don't worry about cascading deletes here — `storage.DeleteProject` already handles the cascade (FOREIGN KEY clauses in migrations). If it returns an integrity error, surface 409 conflict.
+
+**Patterns to follow:**
+- T2-1's `AuthHandler.Login` pattern: `http.MethodPost` check, decode JSON body, validate, sanitize, call service, encode response.
+- `internal/core/app.go:CreateProject` for understanding how the CLI creates projects (uses `platform.GetProgram` to fetch scope; the HTTP version skips this since scope is in the request body).
+- `validation.ProjectName` already exists for name format validation.
+
+**Test scenarios:**
+- **Happy path — list empty**: `GET /api/projects` against an empty store returns 200 + `[]`.
+- **Happy path — list non-empty**: Create two projects, list, expect both in response.
+- **Happy path — get by id**: Create, fetch by id, response matches.
+- **Happy path — create**: Valid POST returns 201 with the created project (including server-assigned ID).
+- **Happy path — delete by admin**: DELETE as admin user returns 204; subsequent GET returns 404.
+- **Edge case — create with empty name**: 400 invalid_field.
+- **Edge case — create with invalid platform**: 400 invalid_field.
+- **Edge case — get nonexistent id**: 404 not_found.
+- **Edge case — delete nonexistent id**: 404 not_found (or 204 idempotent — pick one and document; recommend 404 because the client likely wants to know).
+- **Edge case — delete with project id in URL but record has children**: depends on storage's cascade behavior; if cascade succeeds, 204; if it errors, 409 conflict.
+- **Error path — create with malformed JSON**: 400 invalid_body.
+- **Error path — create as readonly user**: 403 forbidden.
+- **Error path — delete as user (non-admin)**: 403 forbidden.
+- **Error path — any endpoint without bearer token**: 401 unauthorized (handled by AuthMiddleware before reaching the handler — verified in router_test.go integration test, not duplicated here).
+- **Integration — create then list shows the new entry**: full round-trip via httptest.
+- **Integration — delete then get returns 404**.
+
+**Verification:**
+- All test scenarios pass.
+- `go test ./internal/web/handlers/... -count=1 -run TestProjects` green.
+
+---
+
+### U4. Read-only handlers for hosts, endpoints, and tasks
+
+**Goal:** Three structurally identical handler files providing list-by-project and get-by-id for hosts, endpoints, and tasks. No write operations (per D8).
+
+**Requirements:** T2-2 (read-only GETs for hosts/endpoints/tasks).
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- `internal/web/handlers/hosts.go` (new)
+- `internal/web/handlers/hosts_test.go` (new)
+- `internal/web/handlers/endpoints.go` (new)
+- `internal/web/handlers/endpoints_test.go` (new)
+- `internal/web/handlers/tasks.go` (new)
+- `internal/web/handlers/tasks_test.go` (new)
+
+**Approach:**
+
+Each handler is structurally identical:
+
+| Handler | Endpoints |
+|---|---|
+| `HostsHandler` | `GET /api/projects/{id}/hosts`, `GET /api/hosts/{id}` |
+| `EndpointsHandler` | `GET /api/projects/{id}/endpoints`, `GET /api/endpoints/{id}` |
+| `TasksHandler` | `GET /api/projects/{id}/tasks`, `GET /api/tasks/{id}` |
+
+For endpoints' list under project, use `store.ListEndpointsByProject(ctx, projectID)` (the project-flat method, not the per-host one). The per-host list (`GET /api/hosts/{id}/endpoints`) is potentially nice but not in T2-2's stated scope — defer.
+
+All three handlers:
+- Constructor `New<Entity>Handler(store storage.Store, logger *utils.Logger)`
+- `RegisterRoutes(mux, authedChain)` registering both routes via `middleware.Chain`
+- No role gating — all reads available to any authenticated user (including readonly)
+- 404 when the parent project or the entity doesn't exist
+- 200 + JSON array for list (empty array for no entries, not 204 — list endpoints should always return arrays per REST convention)
+- 200 + JSON object for single entity
+
+The boilerplate similarity is intentional: each file is ~70 lines, mostly mechanical. If the third file feels too redundant by execution time, consider extracting a small generic helper, but don't pre-abstract before the duplication is visible (per CLAUDE.md "rule of three").
+
+**Patterns to follow:**
+- U3's `ProjectsHandler` provides the constructor + `RegisterRoutes` template.
+- `r.PathValue("id")` for both `{pid}` (parent project id) and `{id}` (entity id) — Go 1.22 standard.
+
+**Test scenarios** (per handler — adjust entity names):
+- **Happy path — list under project**: Create a project, create entities under it via the storage layer directly, GET the list endpoint, verify all returned.
+- **Happy path — list with no entries**: 200 + `[]` (NOT 204).
+- **Happy path — get by id**: Create entity, GET by id, response matches.
+- **Edge case — list under nonexistent project**: should the handler 404 first (verify project exists) or just return `[]`? Recommend: just return `[]` — list endpoints don't require parent existence verification (avoids extra DB round trip; client can `GET /api/projects/{id}` separately to check existence).
+- **Edge case — get by nonexistent id**: 404 not_found.
+- **Integration — recon-style population**: Create a project, simulate recon-service inserts, list returns them.
+
+For the third handler in this batch, consider whether the test-scenario list can be tightened to a smaller core set after the first two confirm the pattern. Don't pad scenarios that are mechanically identical.
+
+**Verification:**
+- All scenarios pass for each handler.
+- `go test ./internal/web/handlers/... -count=1 -run "TestHosts|TestEndpoints|TestTasks"` green.
+
+---
+
+### U5. Findings handler — read + PATCH mutation
+
+**Goal:** Implement `FindingsHandler` covering List, Get, and PATCH (status / severity update). PATCH uses the unified-allow-list pattern from D2.
+
+**Requirements:** T2-2 (findings read + mutation).
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- `internal/web/handlers/findings.go` (new)
+- `internal/web/handlers/findings_test.go` (new)
+
+**Approach:**
+
+Endpoints:
+
+| Method | Path | Behavior | Auth |
+|---|---|---|---|
+| `GET` | `/api/projects/{id}/findings` | List via `store.ListFindings(ctx, projectID)` | any user |
+| `GET` | `/api/findings/{id}` | `store.GetFinding(ctx, id)` | any user |
+| `PATCH` | `/api/findings/{id}` | Decode allow-listed fields; merge into existing; `store.UpdateFinding(ctx, finding)` | user or admin |
+
+PATCH body shape (allow-list):
+- `status`: optional, must be one of `models.FindingStatus*` constants
+- `severity`: optional, must be one of `models.FindingSeverity*` constants
+
+Handler logic for PATCH:
+1. Fetch current finding via `store.GetFinding(ctx, id)`. If 404 → 404.
+2. Decode body into a struct with optional pointer fields (so unset fields are distinguishable from zero values).
+3. If both fields are nil → 400 invalid_body "no allowed fields to update".
+4. Validate each provided field against the model constants. Reject with 400 invalid_field if invalid.
+5. Apply the changes onto the fetched finding.
+6. Set `finding.UpdatedAt = time.Now()` (or rely on the storage layer if it handles this — verify in U5 against `store.UpdateFinding` behavior).
+7. Call `store.UpdateFinding(ctx, finding)`.
+8. Return 200 + updated finding.
+
+Document the allow-list in a code comment so the next contributor knows where to add new mutable fields.
+
+**Patterns to follow:**
+- U3's role-check inline pattern.
+- Existing `models.FindingStatus*` and `models.FindingSeverity*` constants in `pkg/models/models.go` for validation.
+- `internal/storage/finding.go:UpdateFinding` for understanding what the storage layer does with the passed finding (in particular, whether it updates `UpdatedAt` itself).
+
+**Test scenarios:**
+- **Happy path — list**: Create finding(s), GET list, all returned.
+- **Happy path — get by id**: created finding fetched correctly.
+- **Happy path — patch status only**: PATCH `{"status": "triaged"}` changes status; response shows new value; severity unchanged.
+- **Happy path — patch severity only**: PATCH `{"severity": "high"}` similarly.
+- **Happy path — patch both**: PATCH `{"status": "...", "severity": "..."}` changes both atomically.
+- **Edge case — patch with empty body**: 400 invalid_body "no allowed fields".
+- **Edge case — patch with only ignored fields** (e.g., `{"title": "different"}`): 400 invalid_body "no allowed fields" — title is not in the allow-list, so the request effectively had no allowed updates.
+- **Edge case — patch with invalid status value**: 400 invalid_field "status".
+- **Edge case — patch with invalid severity value**: 400 invalid_field "severity".
+- **Edge case — patch nonexistent id**: 404 not_found.
+- **Error path — patch as readonly user**: 403 forbidden.
+- **Error path — patch with malformed JSON**: 400 invalid_body.
+- **Integration — patch then get returns updated value**.
+- **Integration — patch is atomic when both fields valid**: storage layer either commits both or neither (if the storage UpdateFinding is transactional).
+
+**Verification:**
+- All scenarios pass.
+- `go test ./internal/web/handlers/... -count=1 -run TestFindings` green.
+
+---
+
+### U6. Wire all handlers in `buildRouter`; add integration test for the full data API surface
+
+**Goal:** Connect U3-U5 handlers to the running server. Add an integration test in `internal/web/router_test.go` that exercises representative endpoints end-to-end through the full middleware stack.
+
+**Requirements:** T2-2 wiring.
+
+**Dependencies:** U1, U2, U3, U4, U5.
+
+**Files:**
+- `internal/web/server.go` (modify): in `buildRouter`, after auth-route registration block, add data-handler construction + RegisterRoutes calls
+- `internal/web/router_test.go` (modify): add data-API integration tests (route-registration smoke checks; full happy-path: login → create project → list)
+
+**Approach:**
+
+In `buildRouter`, after the existing auth-route block, add:
+
+```text
+if s.deps.Store == nil {
+    s.logger.Warn("Store is nil; skipping data-model route registration")
+    return s.applyCORS(mux)
+}
+
+projectsHandler := handlers.NewProjectsHandler(s.deps.Store, s.logger)
+projectsHandler.RegisterRoutes(mux, authedAuth)
+
+hostsHandler := handlers.NewHostsHandler(s.deps.Store, s.logger)
+hostsHandler.RegisterRoutes(mux, authedAuth)
+
+// ...endpoints, findings, tasks similar
+```
+
+Pass `authedAuth` (the existing authed chain) to all handlers — they all require authentication; per-route role gating is internal to the handler.
+
+For tests:
+- Existing `newTestServerWithAuth(t)` already wires Store-less auth-only setup. Add `newTestServerWithStoreAndAuth(t)` that wires both.
+- Add `TestRouter_AllDataRoutesRegistered` similar to T2-1's auth-route registration test — list every new route, GET/POST against it, confirm not-404.
+- Add `TestRouter_NilStoreSkipsDataRoutes` — Dependencies with AuthService but no Store; data routes 404; auth routes still work.
+- Add one happy-path integration test: login as a fresh user → POST /api/projects → GET /api/projects/{id} → DELETE.
+- Add `TestRouter_AdminRequiredForProjectDelete` — DELETE as RoleUser returns 403; DELETE as RoleAdmin returns 204.
+
+**Patterns to follow:**
+- T2-1's auth-route registration block in `buildRouter` (PR #19).
+- T2-1's `TestRouter_AllSixAuthRoutesRegistered` for the route-registration smoke test pattern.
+- `setupAuthBackend(t)` in `internal/web/router_test.go` for the in-memory SQLite + auth.Service helper. Will need a sibling `setupStorageBackend(t)` that sets up the application's storage.Store on the same DB (or a separate one).
+
+**Test scenarios:**
+- **Happy path — all 13 routes registered**: each returns something other than 404 with valid bearer token.
+- **Edge case — Store nil**: AuthService set but Store nil; data routes 404; auth routes still work.
+- **Integration — full project lifecycle**: login → POST project (as user) → list (as user, expect 1 entry) → DELETE (as admin) → list (as user, expect 0 entries).
+- **Integration — readonly user can list and get but not create**: login as readonly, GET list 200, POST 403.
+- **Integration — admin-required for project delete**: login as user, DELETE returns 403; login as admin, DELETE 204.
+- **Integration — all 13 routes go through middleware stack**: pick one route per entity, verify security headers + body-size limit applied (proves wiring matches the auth-route pattern).
+
+**Verification:**
+- All integration tests pass.
+- `gh pr checks` (when PR is open): all CI checks green except the upstream Go 1.25.10 security check (which we know is unrelated).
+- Live `curl http://localhost:8080/api/projects -H "Authorization: Bearer <token>"` returns JSON.
+
+---
+
+## System-Wide Impact
+
+| Surface | Before | After |
+|---|---|---|
+| Web API endpoints | 6 (auth) + 3 (health/index/static) | 19+ — adds 13 data endpoints across 5 entities |
+| `web.Dependencies` shape | `{AuthService, StaticDir}` | `{AuthService, StaticDir, Store}` |
+| `internal/web/handlers/` files | 1 (`auth.go`) | 6 — adds projects, hosts, endpoints, findings, tasks, response helpers |
+| `Server.buildRouter` complexity | Inline route registration | Per-handler `RegisterRoutes` calls |
+| Error response shape across handlers | Inconsistent (auth uses `http.Error`) | Standardized via `writeError` for new handlers; auth handler unchanged in this PR |
+| Role enforcement | Middleware-only (`AuthMiddleware`) | Per-route inline role checks (`user.HasPermission`) on writes |
+| CLI behavior | unchanged | unchanged |
+
+**Affected parties:**
+- **Web UI** (T2-3, future) — has data to render; this is the API the dashboard will call.
+- **Operators** running scans — gain HTTP visibility into in-flight tasks via `GET /api/projects/{id}/tasks`.
+- **Future contributors writing handlers** (T3-1, etc.) — get a clear template to follow: response helpers, RegisterRoutes pattern, inline role checks.
+- **API consumers** (curl, scripts, future client libraries) — get a stable JSON contract.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- 13 endpoints across the 5 named entities (projects, hosts, endpoints, findings, tasks).
+- Response/request helpers (`writeJSON`, `writeError`, `decodeJSON`).
+- Per-route role enforcement for writes.
+- Wiring through `buildRouter` and integration tests.
+
+### Deferred to Follow-Up Work
+
+- **Reports endpoints** — `Reports` has a different storage shape (`Create` returns the report; no `Update`) and ties to the `report.Service` generation pipeline. Worth its own design pass.
+- **Bulk-create endpoints** (`POST /api/projects/{id}/hosts:bulk`, etc.) — `storage.BulkCreate*` methods exist but exposing them via REST adds API-design questions (response shape for partial failures, idempotency keys). Defer until there's a concrete client need.
+- **Pagination** (`?limit=`, `?cursor=`) — invasive change to the storage interface. Add when list sizes warrant it.
+- **OpenAPI spec generation** — could be added as a separate PR; introducing OpenAPI tooling is its own decision.
+- **WebSocket / SSE for real-time scan progress** — T4-2 in the brainstorm.
+- **Per-host endpoint listing** (`GET /api/hosts/{id}/endpoints`) — `storage.ListEndpoints(hostID)` exists but the list-by-project covers most use cases; add when a UI-driven need surfaces.
+- **`PUT /api/projects/{id}` (full project update)** — brainstorm scope is List/Get/Create/Delete. Adding update is non-trivial because Project has nested `Scope` whose merge semantics need definition.
+
+### Not chasing
+
+- **Manual project creation flow validation** — T3-1 owns the "manual" platform validation logic. T2-2's POST /api/projects accepts whatever platforms the existing `validation` package allows, including "manual" once T3-1 lands.
+- **Finding status workflow validation** (e.g., "can't go from Closed back to New") — T2-2 enforces value validity but not state transitions. Add as a Tier 4 polish if needed.
+- **Multi-user RBAC beyond admin/user/readonly** — out of scope per brainstorm.
+- **CLI changes** — CLI continues to use the storage layer directly. The HTTP API is additive.
+
+---
+
+## Open Questions
+
+These are intentionally not pre-answered; the implementer resolves at execution time and notes the choice in the commit message.
+
+1. **DELETE idempotency**: should `DELETE /api/projects/{id}` for a nonexistent id return 404 (informing the client) or 204 (idempotent)? The plan recommends 404; implementer can swap if there's a strong client preference.
+2. **`UpdatedAt` stamping**: does `storage.UpdateFinding` automatically update `UpdatedAt`, or does the handler need to set it explicitly? Read `internal/storage/finding.go:UpdateFinding` at execution time to confirm.
+3. **Finding mutation atomicity**: if `store.UpdateFinding` is non-transactional and a concurrent request also patches the same finding, we get last-writer-wins. Acceptable for v1? The plan assumes yes — in-process triage is rarely concurrent. Document the limitation.
+4. **404 vs 200 + empty array for list under nonexistent project**: plan recommends `200 + []`, but some teams prefer a 404 for consistency with single-entity GETs. Implementer picks; document the rationale in code comment.
+
+---
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Inline role checks drift across handlers (one handler forgets to check) | Medium | Medium | The U2 helper pattern + each handler's tests covering "as readonly", "as user", "as admin" catches drift. |
+| Decode-into-existing-struct overrides server-set fields (e.g., client sends `id` in body and overwrites) | High if not guarded | High (security) | In Create handlers, decode into a `request` struct (only client-settable fields), not the Model directly. Document in U3's Approach. |
+| Inconsistent error envelope across new and existing handlers | Low | Low | Plan accepts that auth handler keeps its current pattern; new handlers consistently use the helper. Note in CHANGELOG. |
+| `r.PathValue` returns empty string for typos (e.g., `{pid}` registered, `r.PathValue("id")` reads) | Medium during development | Low (caught by tests) | Convention: parent param is `{id}` for primary entity, `{id}` for nested too. Tests verify path extraction. |
+| Per-handler RegisterRoutes signature drift (one handler accepts `[]chain`, another accepts `chain...`) | Medium | Low | Plan specifies the signature exactly: `RegisterRoutes(mux *http.ServeMux, authedChain []func(http.Handler) http.Handler)`. Lint-style review catches drift. |
+| Forgetting to update `Server.applyCORS` invocation when adding routes | Low | Medium | `applyCORS` already wraps the entire mux at the end of `buildRouter` (T2-1 design); adding new routes via `mux.Handle` automatically benefits. Test verifies CORS works for one of the new routes. |
+| Test fixtures (in-memory SQLite + auth + storage) get heavy and slow | Medium | Low | Reuse `setupAuthBackend(t)` pattern; if a `setupStorageBackend(t)` becomes a hotspot, factor into a shared helper. |
+
+---
+
+## Verification Gate
+
+The plan is complete when **all** of the following pass:
+
+```text
+1. go build ./...                                                 # clean
+2. go test ./... -count=1 -race                                   # all packages green; new handler tests included
+3. golangci-lint run --timeout=3m                                 # zero issues at pinned v1.64.8
+4. curl -i -H "Authorization: Bearer <token>" /api/projects       # 200 + JSON array
+5. curl -X POST -H "Authorization: Bearer <token>" -d {...} /api/projects   # 201 + JSON object with assigned id
+6. curl -X DELETE -H "Authorization: Bearer <admin-token>" /api/projects/{id}   # 204
+7. curl -X PATCH -H "..." -d '{"status":"closed"}' /api/findings/{id}   # 200 + updated finding
+8. grep -n "RegisterRoutes" internal/web/handlers/                # all 5 handlers expose RegisterRoutes
+```
+
+Steps 4-7 require a locally running server (`./zerodaybuddy serve`) and a valid bearer token (obtainable via `POST /api/auth/login` after `POST /api/auth/register`).
+
+---
+
+## Suggested Commit Boundary
+
+Six commits in one PR, one per unit:
+
+1. `feat(web): add Store to web.Dependencies; thread storage through App.Initialize (T2-2 U1)`
+2. `feat(handlers): add response helpers — writeJSON, writeError, decodeJSON (T2-2 U2)`
+3. `feat(handlers): projects CRUD endpoints with role-aware writes (T2-2 U3)`
+4. `feat(handlers): hosts/endpoints/tasks read-only endpoints (T2-2 U4)`
+5. `feat(handlers): findings read + PATCH for status/severity (T2-2 U5)`
+6. `feat(web): wire data handlers in buildRouter + integration tests (T2-2 U6)`
+
+Each unit is independently reviewable; landing them in this order keeps the tree green at every commit (U2 has no dependencies; U3 depends on U1+U2; U6 depends on all preceding).

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -130,6 +130,7 @@ func (a *App) Initialize(ctx context.Context) error {
 	a.webSvc = web.NewServer(a.config.WebServer, web.Dependencies{
 		AuthService: a.authSvc,
 		StaticDir:   staticDir,
+		Store:       a.store,
 	}, a.logger)
 	
 	a.logger.Info("ZeroDayBuddy initialized successfully")

--- a/internal/web/handlers/endpoints.go
+++ b/internal/web/handlers/endpoints.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/internal/web/middleware"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/perplext/zerodaybuddy/pkg/utils"
+)
+
+type endpointStore interface {
+	GetEndpoint(ctx context.Context, id string) (*models.Endpoint, error)
+	ListEndpointsByProject(ctx context.Context, projectID string) ([]*models.Endpoint, error)
+}
+
+// EndpointsHandler exposes read-only HTTP endpoints for the Endpoint entity.
+// Per-host listing (GET /api/hosts/{id}/endpoints) is deferred to a future
+// PR — list-by-project covers the dashboard use case.
+type EndpointsHandler struct {
+	store  endpointStore
+	logger *utils.Logger
+}
+
+func NewEndpointsHandler(store storage.Store, logger *utils.Logger) *EndpointsHandler {
+	return &EndpointsHandler{store: store, logger: logger}
+}
+
+func (h *EndpointsHandler) RegisterRoutes(mux *http.ServeMux, authedChain []func(http.Handler) http.Handler) {
+	mux.Handle("GET /api/projects/{id}/endpoints", middleware.Chain(http.HandlerFunc(h.listByProject), authedChain...))
+	mux.Handle("GET /api/endpoints/{id}", middleware.Chain(http.HandlerFunc(h.get), authedChain...))
+}
+
+func (h *EndpointsHandler) listByProject(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	endpoints, err := h.store.ListEndpointsByProject(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("ListEndpointsByProject(%s) failed: %v", projectID, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to list endpoints", h.logger)
+		return
+	}
+	if endpoints == nil {
+		endpoints = []*models.Endpoint{}
+	}
+	writeJSON(w, http.StatusOK, endpoints, h.logger)
+}
+
+func (h *EndpointsHandler) get(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	endpoint, err := h.store.GetEndpoint(r.Context(), id)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "endpoint not found", h.logger)
+			return
+		}
+		h.logger.Error("GetEndpoint(%s) failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to fetch endpoint", h.logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, endpoint, h.logger)
+}
+
+var _ endpointStore = (storage.Store)(nil)

--- a/internal/web/handlers/endpoints_test.go
+++ b/internal/web/handlers/endpoints_test.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEndpointStore struct {
+	endpoints map[string]*models.Endpoint
+	listErr   error
+	getErr    error
+}
+
+func (f *fakeEndpointStore) GetEndpoint(_ context.Context, id string) (*models.Endpoint, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	e, ok := f.endpoints[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return e, nil
+}
+
+func (f *fakeEndpointStore) ListEndpointsByProject(_ context.Context, projectID string) ([]*models.Endpoint, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := []*models.Endpoint{}
+	for _, e := range f.endpoints {
+		if e.ProjectID == projectID {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+func newEndpointsHandlerWithFake(s endpointStore) *EndpointsHandler {
+	return &EndpointsHandler{store: s, logger: newTestLogger()}
+}
+
+func TestEndpointsListByProject_HappyPath(t *testing.T) {
+	store := &fakeEndpointStore{endpoints: map[string]*models.Endpoint{
+		"e1": {ID: "e1", ProjectID: "p1", URL: "https://a/1"},
+		"e2": {ID: "e2", ProjectID: "p1", URL: "https://a/2"},
+		"e3": {ID: "e3", ProjectID: "other", URL: "https://b/1"},
+	}}
+	h := newEndpointsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/endpoints", "p1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []models.Endpoint
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestEndpointsListByProject_NoEntriesReturnsEmptyArray(t *testing.T) {
+	h := newEndpointsHandlerWithFake(&fakeEndpointStore{endpoints: map[string]*models.Endpoint{}})
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/empty/endpoints", "empty", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "[]\n", w.Body.String())
+}
+
+func TestEndpointsListByProject_StoreError500(t *testing.T) {
+	h := newEndpointsHandlerWithFake(&fakeEndpointStore{listErr: errors.New("db down")})
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/endpoints", "p1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorCode(t, w, ErrCodeInternal)
+}
+
+func TestEndpointsGet_HappyPath(t *testing.T) {
+	store := &fakeEndpointStore{endpoints: map[string]*models.Endpoint{
+		"e1": {ID: "e1", URL: "https://a/1"},
+	}}
+	h := newEndpointsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/endpoints/e1", "e1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got models.Endpoint
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "e1", got.ID)
+}
+
+func TestEndpointsGet_NotFound(t *testing.T) {
+	h := newEndpointsHandlerWithFake(&fakeEndpointStore{endpoints: map[string]*models.Endpoint{}})
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/endpoints/missing", "missing", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorCode(t, w, ErrCodeNotFound)
+}

--- a/internal/web/handlers/findings.go
+++ b/internal/web/handlers/findings.go
@@ -1,0 +1,169 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/internal/web/middleware"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/perplext/zerodaybuddy/pkg/utils"
+)
+
+type findingStore interface {
+	GetFinding(ctx context.Context, id string) (*models.Finding, error)
+	UpdateFinding(ctx context.Context, finding *models.Finding) error
+	ListFindings(ctx context.Context, projectID string) ([]*models.Finding, error)
+}
+
+// FindingsHandler exposes HTTP endpoints for the Finding entity:
+// list-by-project, get-by-id, and PATCH for status / severity.
+type FindingsHandler struct {
+	store  findingStore
+	logger *utils.Logger
+}
+
+func NewFindingsHandler(store storage.Store, logger *utils.Logger) *FindingsHandler {
+	return &FindingsHandler{store: store, logger: logger}
+}
+
+func (h *FindingsHandler) RegisterRoutes(mux *http.ServeMux, authedChain []func(http.Handler) http.Handler) {
+	mux.Handle("GET /api/projects/{id}/findings", middleware.Chain(http.HandlerFunc(h.listByProject), authedChain...))
+	mux.Handle("GET /api/findings/{id}", middleware.Chain(http.HandlerFunc(h.get), authedChain...))
+	mux.Handle("PATCH /api/findings/{id}", middleware.Chain(http.HandlerFunc(h.patch), authedChain...))
+}
+
+// patchFindingRequest is the explicit allow-list for PATCH /api/findings/{id}.
+// Pointer fields distinguish "not set in request" (nil) from "set to empty"
+// (non-nil pointer to zero value). Adding a new mutable field requires:
+//
+//  1. adding a pointer field here
+//  2. validating it in patch()
+//  3. applying it to the loaded finding in patch()
+type patchFindingRequest struct {
+	Status   *models.FindingStatus   `json:"status,omitempty"`
+	Severity *models.FindingSeverity `json:"severity,omitempty"`
+}
+
+func (h *FindingsHandler) listByProject(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	findings, err := h.store.ListFindings(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("ListFindings(%s) failed: %v", projectID, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to list findings", h.logger)
+		return
+	}
+	if findings == nil {
+		findings = []*models.Finding{}
+	}
+	writeJSON(w, http.StatusOK, findings, h.logger)
+}
+
+func (h *FindingsHandler) get(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	finding, err := h.store.GetFinding(r.Context(), id)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "finding not found", h.logger)
+			return
+		}
+		h.logger.Error("GetFinding(%s) failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to fetch finding", h.logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, finding, h.logger)
+}
+
+func (h *FindingsHandler) patch(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", h.logger)
+		return
+	}
+	if !user.HasPermission(auth.RoleUser) {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "user role required to update findings", h.logger)
+		return
+	}
+
+	id := r.PathValue("id")
+
+	var req patchFindingRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidBody, "invalid JSON body: "+err.Error(), h.logger)
+		return
+	}
+
+	// Reject requests that contain no allow-listed fields. This catches both
+	// the empty-body case and the case where the client sent only ignored
+	// fields (e.g., {"title": "..."} — title is not patchable here).
+	if req.Status == nil && req.Severity == nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidBody, "no allowed fields to update; valid fields: status, severity", h.logger)
+		return
+	}
+
+	// Validate enum values before fetching — fail fast on bad input.
+	if req.Status != nil && !isValidFindingStatus(*req.Status) {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidField, "status: must be one of new, confirmed, duplicate, false_positive, reported, resolved", h.logger)
+		return
+	}
+	if req.Severity != nil && !isValidFindingSeverity(*req.Severity) {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidField, "severity: must be one of critical, high, medium, low, info", h.logger)
+		return
+	}
+
+	// Load existing finding (also gives us 404 for missing id).
+	finding, err := h.store.GetFinding(r.Context(), id)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "finding not found", h.logger)
+			return
+		}
+		h.logger.Error("GetFinding(%s) before patch failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to fetch finding", h.logger)
+		return
+	}
+
+	// Apply allow-listed updates.
+	if req.Status != nil {
+		finding.Status = *req.Status
+	}
+	if req.Severity != nil {
+		finding.Severity = *req.Severity
+	}
+
+	if err := h.store.UpdateFinding(r.Context(), finding); err != nil {
+		h.logger.Error("UpdateFinding(%s) failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to update finding", h.logger)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, finding, h.logger)
+}
+
+func isValidFindingStatus(s models.FindingStatus) bool {
+	switch s {
+	case models.FindingStatusNew,
+		models.FindingStatusConfirmed,
+		models.FindingStatusDuplicate,
+		models.FindingStatusFalsePositive,
+		models.FindingStatusReported,
+		models.FindingStatusResolved:
+		return true
+	}
+	return false
+}
+
+func isValidFindingSeverity(s models.FindingSeverity) bool {
+	switch s {
+	case models.SeverityCritical,
+		models.SeverityHigh,
+		models.SeverityMedium,
+		models.SeverityLow,
+		models.SeverityInfo:
+		return true
+	}
+	return false
+}
+
+var _ findingStore = (storage.Store)(nil)

--- a/internal/web/handlers/findings_test.go
+++ b/internal/web/handlers/findings_test.go
@@ -1,0 +1,248 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeFindingStore struct {
+	findings  map[string]*models.Finding
+	getErr    error
+	listErr   error
+	updateErr error
+}
+
+func (f *fakeFindingStore) GetFinding(_ context.Context, id string) (*models.Finding, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	fd, ok := f.findings[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return fd, nil
+}
+
+func (f *fakeFindingStore) UpdateFinding(_ context.Context, finding *models.Finding) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	f.findings[finding.ID] = finding
+	return nil
+}
+
+func (f *fakeFindingStore) ListFindings(_ context.Context, projectID string) ([]*models.Finding, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := []*models.Finding{}
+	for _, fd := range f.findings {
+		if fd.ProjectID == projectID {
+			out = append(out, fd)
+		}
+	}
+	return out, nil
+}
+
+func newFindingsHandlerWithFake(s findingStore) *FindingsHandler {
+	return &FindingsHandler{store: s, logger: newTestLogger()}
+}
+
+func patchReq(target, idValue string, body []byte, user *auth.User) *http.Request {
+	r := httptest.NewRequest(http.MethodPatch, target, bytes.NewReader(body))
+	if user != nil {
+		r = r.WithContext(contextWithUserForTest(r.Context(), user))
+	}
+	r.SetPathValue("id", idValue)
+	return r
+}
+
+// -- LIST / GET --
+
+func TestFindingsListByProject_HappyPath(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{
+		"f1": {ID: "f1", ProjectID: "p1", Title: "XSS"},
+		"f2": {ID: "f2", ProjectID: "p1", Title: "SQLi"},
+		"f3": {ID: "f3", ProjectID: "other", Title: "elsewhere"},
+	}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/findings", "p1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []models.Finding
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestFindingsListByProject_StoreError500(t *testing.T) {
+	h := newFindingsHandlerWithFake(&fakeFindingStore{listErr: errors.New("db down")})
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/findings", "p1", userOf(auth.RoleReadOnly)))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorCode(t, w, ErrCodeInternal)
+}
+
+func TestFindingsGet_HappyPath(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{
+		"f1": {ID: "f1", Title: "XSS", Status: models.FindingStatusNew, Severity: models.SeverityMedium},
+	}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/findings/f1", "f1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got models.Finding
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "f1", got.ID)
+}
+
+func TestFindingsGet_NotFound(t *testing.T) {
+	h := newFindingsHandlerWithFake(&fakeFindingStore{findings: map[string]*models.Finding{}})
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/findings/missing", "missing", userOf(auth.RoleReadOnly)))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorCode(t, w, ErrCodeNotFound)
+}
+
+// -- PATCH happy paths --
+
+func TestFindingsPatch_StatusOnly(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{
+		"f1": {ID: "f1", Status: models.FindingStatusNew, Severity: models.SeverityMedium},
+	}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"status":"confirmed"}`), userOf(auth.RoleUser)))
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, models.FindingStatusConfirmed, store.findings["f1"].Status)
+	assert.Equal(t, models.SeverityMedium, store.findings["f1"].Severity, "severity unchanged when not in patch")
+}
+
+func TestFindingsPatch_SeverityOnly(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{
+		"f1": {ID: "f1", Status: models.FindingStatusNew, Severity: models.SeverityMedium},
+	}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"severity":"high"}`), userOf(auth.RoleUser)))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, models.SeverityHigh, store.findings["f1"].Severity)
+	assert.Equal(t, models.FindingStatusNew, store.findings["f1"].Status)
+}
+
+func TestFindingsPatch_BothFieldsAtomically(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{
+		"f1": {ID: "f1", Status: models.FindingStatusNew, Severity: models.SeverityMedium},
+	}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"status":"resolved","severity":"low"}`), userOf(auth.RoleUser)))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, models.FindingStatusResolved, store.findings["f1"].Status)
+	assert.Equal(t, models.SeverityLow, store.findings["f1"].Severity)
+}
+
+// -- PATCH allow-list rejection --
+
+func TestFindingsPatch_EmptyBody_400(t *testing.T) {
+	h := newFindingsHandlerWithFake(&fakeFindingStore{findings: map[string]*models.Finding{}})
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{}`), userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidBody)
+}
+
+func TestFindingsPatch_OnlyIgnoredFields_400(t *testing.T) {
+	// Client sends a field that's not in the allow-list. The decode silently
+	// drops it (encoding/json default), then the handler rejects because no
+	// allowed fields were set.
+	store := &fakeFindingStore{findings: map[string]*models.Finding{
+		"f1": {ID: "f1", Title: "original", Status: models.FindingStatusNew},
+	}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"title":"hijacked"}`), userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidBody)
+	assert.Equal(t, "original", store.findings["f1"].Title, "title must NOT be patchable; allow-list must hold")
+}
+
+// -- PATCH validation --
+
+func TestFindingsPatch_InvalidStatus_400(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{"f1": {ID: "f1"}}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"status":"nonsense"}`), userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidField)
+}
+
+func TestFindingsPatch_InvalidSeverity_400(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{"f1": {ID: "f1"}}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"severity":"nuclear"}`), userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidField)
+}
+
+func TestFindingsPatch_NotFound(t *testing.T) {
+	h := newFindingsHandlerWithFake(&fakeFindingStore{findings: map[string]*models.Finding{}})
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/missing", "missing", []byte(`{"status":"resolved"}`), userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorCode(t, w, ErrCodeNotFound)
+}
+
+// -- PATCH role and auth checks --
+
+func TestFindingsPatch_AsReadonly_Forbidden(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{"f1": {ID: "f1"}}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"status":"resolved"}`), userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assertErrorCode(t, w, ErrCodeForbidden)
+}
+
+func TestFindingsPatch_NoUser_Unauthorized(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{"f1": {ID: "f1"}}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{"status":"resolved"}`), nil))
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assertErrorCode(t, w, ErrCodeUnauthorized)
+}
+
+func TestFindingsPatch_InvalidJSON_400(t *testing.T) {
+	store := &fakeFindingStore{findings: map[string]*models.Finding{"f1": {ID: "f1"}}}
+	h := newFindingsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.patch(w, patchReq("/api/findings/f1", "f1", []byte(`{not json}`), userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidBody)
+}

--- a/internal/web/handlers/hosts.go
+++ b/internal/web/handlers/hosts.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/internal/web/middleware"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/perplext/zerodaybuddy/pkg/utils"
+)
+
+type hostStore interface {
+	GetHost(ctx context.Context, id string) (*models.Host, error)
+	ListHosts(ctx context.Context, projectID string) ([]*models.Host, error)
+}
+
+// HostsHandler exposes read-only HTTP endpoints for the Host entity.
+// Hosts are created by the recon service, not by users — see plan D8.
+type HostsHandler struct {
+	store  hostStore
+	logger *utils.Logger
+}
+
+func NewHostsHandler(store storage.Store, logger *utils.Logger) *HostsHandler {
+	return &HostsHandler{store: store, logger: logger}
+}
+
+func (h *HostsHandler) RegisterRoutes(mux *http.ServeMux, authedChain []func(http.Handler) http.Handler) {
+	mux.Handle("GET /api/projects/{id}/hosts", middleware.Chain(http.HandlerFunc(h.listByProject), authedChain...))
+	mux.Handle("GET /api/hosts/{id}", middleware.Chain(http.HandlerFunc(h.get), authedChain...))
+}
+
+func (h *HostsHandler) listByProject(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	hosts, err := h.store.ListHosts(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("ListHosts(%s) failed: %v", projectID, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to list hosts", h.logger)
+		return
+	}
+	if hosts == nil {
+		hosts = []*models.Host{}
+	}
+	writeJSON(w, http.StatusOK, hosts, h.logger)
+}
+
+func (h *HostsHandler) get(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	host, err := h.store.GetHost(r.Context(), id)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "host not found", h.logger)
+			return
+		}
+		h.logger.Error("GetHost(%s) failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to fetch host", h.logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, host, h.logger)
+}
+
+// Compile-time assertion that storage.Store satisfies hostStore.
+var _ hostStore = (storage.Store)(nil)

--- a/internal/web/handlers/hosts_test.go
+++ b/internal/web/handlers/hosts_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHostStore struct {
+	hosts   map[string]*models.Host
+	listErr error
+	getErr  error
+}
+
+func (f *fakeHostStore) GetHost(_ context.Context, id string) (*models.Host, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	h, ok := f.hosts[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return h, nil
+}
+
+func (f *fakeHostStore) ListHosts(_ context.Context, projectID string) ([]*models.Host, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := []*models.Host{}
+	for _, h := range f.hosts {
+		if h.ProjectID == projectID {
+			out = append(out, h)
+		}
+	}
+	return out, nil
+}
+
+func newHostsHandlerWithFake(s hostStore) *HostsHandler {
+	return &HostsHandler{store: s, logger: newTestLogger()}
+}
+
+// reqWithUserCustomPath is like reqWithUser but lets the caller specify the
+// PathValue("id") explicitly — the auto-extraction in projects_test.go assumes
+// /api/projects/{id}; for /api/projects/{pid}/hosts and /api/hosts/{id} we
+// want explicit control.
+func reqWithUserCustomPath(method, target, idValue string, user *auth.User) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	if user != nil {
+		r = r.WithContext(useUser(r.Context(), user))
+	}
+	r.SetPathValue("id", idValue)
+	return r
+}
+
+// useUser is a thin wrapper so tests don't need to import middleware here.
+// (The tests for projects do import middleware; here we keep the dependency
+// surface tighter for the read-only handler test files.)
+func useUser(ctx context.Context, u *auth.User) context.Context {
+	return contextWithUserForTest(ctx, u)
+}
+
+func TestHostsListByProject_HappyPath(t *testing.T) {
+	store := &fakeHostStore{hosts: map[string]*models.Host{
+		"h1": {ID: "h1", ProjectID: "p1", Value: "a.example.com"},
+		"h2": {ID: "h2", ProjectID: "p1", Value: "b.example.com"},
+		"h3": {ID: "h3", ProjectID: "p-other", Value: "c.example.com"},
+	}}
+	h := newHostsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/hosts", "p1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []models.Host
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 2, "only hosts for p1 should be returned, not p-other")
+}
+
+func TestHostsListByProject_NoEntriesReturnsEmptyArray(t *testing.T) {
+	h := newHostsHandlerWithFake(&fakeHostStore{hosts: map[string]*models.Host{}})
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/empty/hosts", "empty", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "[]\n", w.Body.String())
+}
+
+func TestHostsListByProject_StoreError500(t *testing.T) {
+	h := newHostsHandlerWithFake(&fakeHostStore{listErr: errors.New("db down")})
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/hosts", "p1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorCode(t, w, ErrCodeInternal)
+}
+
+func TestHostsGet_HappyPath(t *testing.T) {
+	store := &fakeHostStore{hosts: map[string]*models.Host{
+		"h1": {ID: "h1", Value: "a.example.com"},
+	}}
+	h := newHostsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/hosts/h1", "h1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got models.Host
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "h1", got.ID)
+}
+
+func TestHostsGet_NotFound(t *testing.T) {
+	h := newHostsHandlerWithFake(&fakeHostStore{hosts: map[string]*models.Host{}})
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/hosts/missing", "missing", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorCode(t, w, ErrCodeNotFound)
+}

--- a/internal/web/handlers/projects.go
+++ b/internal/web/handlers/projects.go
@@ -1,0 +1,213 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/internal/web/middleware"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/perplext/zerodaybuddy/pkg/utils"
+	"github.com/perplext/zerodaybuddy/pkg/validation"
+)
+
+// projectStore is the subset of storage.Store the projects handler uses.
+// Narrowing to a small interface makes test doubles easier and documents
+// the surface area touched by this handler.
+type projectStore interface {
+	CreateProject(ctx context.Context, project *models.Project) error
+	GetProject(ctx context.Context, id string) (*models.Project, error)
+	ListProjects(ctx context.Context) ([]*models.Project, error)
+	DeleteProject(ctx context.Context, id string) error
+}
+
+// ProjectsHandler exposes HTTP endpoints for the Project entity.
+type ProjectsHandler struct {
+	store  projectStore
+	logger *utils.Logger
+}
+
+// NewProjectsHandler constructs a ProjectsHandler. The store argument
+// accepts the full storage.Store; the handler narrows to the methods it uses.
+func NewProjectsHandler(store storage.Store, logger *utils.Logger) *ProjectsHandler {
+	return &ProjectsHandler{store: store, logger: logger}
+}
+
+// RegisterRoutes wires the projects routes onto mux. All routes go through
+// authedChain (authentication required); per-route role checks happen inside
+// the handler methods.
+func (h *ProjectsHandler) RegisterRoutes(mux *http.ServeMux, authedChain []func(http.Handler) http.Handler) {
+	mux.Handle("GET /api/projects", middleware.Chain(http.HandlerFunc(h.list), authedChain...))
+	mux.Handle("POST /api/projects", middleware.Chain(http.HandlerFunc(h.create), authedChain...))
+	mux.Handle("GET /api/projects/{id}", middleware.Chain(http.HandlerFunc(h.get), authedChain...))
+	mux.Handle("DELETE /api/projects/{id}", middleware.Chain(http.HandlerFunc(h.delete), authedChain...))
+}
+
+// createProjectRequest is the explicit allow-list of client-settable fields
+// for POST /api/projects. Decoding into this struct (rather than directly
+// into models.Project) prevents clients from smuggling server-set fields
+// like ID, CreatedAt, or UpdatedAt.
+type createProjectRequest struct {
+	Name        string               `json:"name"`
+	Handle      string               `json:"handle"`
+	Platform    string               `json:"platform"`
+	Type        models.ProjectType   `json:"type"`
+	Description string               `json:"description"`
+	Status      models.ProjectStatus `json:"status"`
+	Scope       models.Scope         `json:"scope"`
+	Notes       string               `json:"notes"`
+}
+
+func (h *ProjectsHandler) list(w http.ResponseWriter, r *http.Request) {
+	projects, err := h.store.ListProjects(r.Context())
+	if err != nil {
+		h.logger.Error("ListProjects failed: %v", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to list projects", h.logger)
+		return
+	}
+	if projects == nil {
+		projects = []*models.Project{}
+	}
+	writeJSON(w, http.StatusOK, projects, h.logger)
+}
+
+func (h *ProjectsHandler) get(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	project, err := h.store.GetProject(r.Context(), id)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "project not found", h.logger)
+			return
+		}
+		h.logger.Error("GetProject(%s) failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to fetch project", h.logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, project, h.logger)
+}
+
+func (h *ProjectsHandler) create(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", h.logger)
+		return
+	}
+	if !user.HasPermission(auth.RoleUser) {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "user role required to create projects", h.logger)
+		return
+	}
+
+	var req createProjectRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidBody, "invalid JSON body: "+err.Error(), h.logger)
+		return
+	}
+
+	req.Name = validation.SanitizeString(req.Name)
+	req.Handle = validation.SanitizeString(req.Handle)
+	req.Description = validation.SanitizeString(req.Description)
+
+	if err := validation.ProjectName(req.Name); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidField, "name: "+err.Error(), h.logger)
+		return
+	}
+	if req.Handle != "" {
+		if err := validation.Handle(req.Handle); err != nil {
+			writeError(w, http.StatusBadRequest, ErrCodeInvalidField, "handle: "+err.Error(), h.logger)
+			return
+		}
+	}
+	if err := validation.Platform(req.Platform); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidField, "platform: "+err.Error(), h.logger)
+		return
+	}
+	if req.Type != "" && !isValidProjectType(req.Type) {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidField, "type: must be one of bug-bounty, vdp, research, pentest", h.logger)
+		return
+	}
+	if req.Status != "" && !isValidProjectStatus(req.Status) {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidField, "status: must be one of active, archived, completed", h.logger)
+		return
+	}
+
+	if req.Type == "" {
+		req.Type = models.ProjectTypeBugBounty
+	}
+	if req.Status == "" {
+		req.Status = models.ProjectStatusActive
+	}
+	if req.Handle == "" {
+		req.Handle = req.Name
+	}
+
+	project := &models.Project{
+		Name:        req.Name,
+		Handle:      req.Handle,
+		Platform:    req.Platform,
+		Type:        req.Type,
+		Description: req.Description,
+		StartDate:   utils.CurrentTime(),
+		Status:      req.Status,
+		Scope:       req.Scope,
+		Notes:       req.Notes,
+	}
+
+	if err := h.store.CreateProject(r.Context(), project); err != nil {
+		h.logger.Error("CreateProject failed for %s: %v", req.Name, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to create project", h.logger)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, project, h.logger)
+}
+
+func (h *ProjectsHandler) delete(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", h.logger)
+		return
+	}
+	if !user.HasPermission(auth.RoleAdmin) {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "admin role required to delete projects", h.logger)
+		return
+	}
+
+	id := r.PathValue("id")
+
+	// Verify existence first so a delete on a missing id returns 404
+	// rather than the silent no-op DELETE FROM gives.
+	if _, err := h.store.GetProject(r.Context(), id); err != nil {
+		if isNotFoundErr(err) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "project not found", h.logger)
+			return
+		}
+		h.logger.Error("GetProject(%s) before delete failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to verify project", h.logger)
+		return
+	}
+
+	if err := h.store.DeleteProject(r.Context(), id); err != nil {
+		h.logger.Error("DeleteProject(%s) failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to delete project", h.logger)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func isValidProjectType(t models.ProjectType) bool {
+	switch t {
+	case models.ProjectTypeBugBounty, models.ProjectTypeVDP, models.ProjectTypeResearch, models.ProjectTypePentest:
+		return true
+	}
+	return false
+}
+
+func isValidProjectStatus(s models.ProjectStatus) bool {
+	switch s {
+	case models.ProjectStatusActive, models.ProjectStatusArchived, models.ProjectStatusCompleted:
+		return true
+	}
+	return false
+}

--- a/internal/web/handlers/projects_test.go
+++ b/internal/web/handlers/projects_test.go
@@ -1,0 +1,377 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/internal/web/middleware"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProjectStore is an in-memory test double satisfying the projectStore
+// interface. Real-storage integration is exercised in router_test.go (U6);
+// these tests focus on handler logic in isolation.
+type fakeProjectStore struct {
+	projects   map[string]*models.Project
+	createErr  error
+	getErr     error
+	listErr    error
+	deleteErr  error
+	createHook func(*models.Project)
+}
+
+func newFakeStore() *fakeProjectStore {
+	return &fakeProjectStore{projects: make(map[string]*models.Project)}
+}
+
+func (f *fakeProjectStore) CreateProject(ctx context.Context, p *models.Project) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	if p.ID == "" {
+		p.ID = "fake-id-" + p.Name
+	}
+	if f.createHook != nil {
+		f.createHook(p)
+	}
+	f.projects[p.ID] = p
+	return nil
+}
+
+func (f *fakeProjectStore) GetProject(ctx context.Context, id string) (*models.Project, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	p, ok := f.projects[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeProjectStore) ListProjects(ctx context.Context) ([]*models.Project, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*models.Project, 0, len(f.projects))
+	for _, p := range f.projects {
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func (f *fakeProjectStore) DeleteProject(ctx context.Context, id string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.projects, id)
+	return nil
+}
+
+// newProjectsHandlerWithFake constructs a ProjectsHandler with an in-memory
+// fake. Bypasses the storage.Store coupling in NewProjectsHandler — direct
+// struct construction is fine because the production constructor is just
+// field assignment.
+func newProjectsHandlerWithFake(store projectStore) *ProjectsHandler {
+	return &ProjectsHandler{store: store, logger: newTestLogger()}
+}
+
+func reqWithUser(method, target string, body []byte, user *auth.User) *http.Request {
+	var r *http.Request
+	if body != nil {
+		r = httptest.NewRequest(method, target, bytes.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, target, nil)
+	}
+	if user != nil {
+		r = r.WithContext(middleware.ContextWithUser(r.Context(), user))
+	}
+	// Inject a fake "id" path value so PathValue("id") works without going
+	// through the mux. ServeMux normally populates this; tests that bypass
+	// the mux must set it manually.
+	if id := extractIDFromPath(target); id != "" {
+		r.SetPathValue("id", id)
+	}
+	return r
+}
+
+// extractIDFromPath pulls the last path segment when the URL ends in
+// /api/projects/{id} so tests can set PathValue without hardcoding it.
+func extractIDFromPath(target string) string {
+	const prefix = "/api/projects/"
+	if len(target) <= len(prefix) {
+		return ""
+	}
+	return target[len(prefix):]
+}
+
+func userOf(role auth.UserRole) *auth.User {
+	return &auth.User{ID: "u1", Username: "alice", Role: role, Status: auth.StatusActive}
+}
+
+// -- LIST --
+
+func TestProjectsList_EmptyReturnsEmptyArray(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	w := httptest.NewRecorder()
+	h.list(w, reqWithUser(http.MethodGet, "/api/projects", nil, userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "[]\n", w.Body.String(), "empty list must serialize as JSON array, not null")
+}
+
+func TestProjectsList_NonEmpty(t *testing.T) {
+	store := newFakeStore()
+	store.projects["a"] = &models.Project{ID: "a", Name: "Alpha"}
+	store.projects["b"] = &models.Project{ID: "b", Name: "Beta"}
+
+	h := newProjectsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.list(w, reqWithUser(http.MethodGet, "/api/projects", nil, userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []models.Project
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestProjectsList_StoreError500(t *testing.T) {
+	store := newFakeStore()
+	store.listErr = errors.New("boom")
+	h := newProjectsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.list(w, reqWithUser(http.MethodGet, "/api/projects", nil, userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorCode(t, w, ErrCodeInternal)
+}
+
+// -- GET --
+
+func TestProjectsGet_HappyPath(t *testing.T) {
+	store := newFakeStore()
+	store.projects["abc"] = &models.Project{ID: "abc", Name: "Alpha"}
+	h := newProjectsHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUser(http.MethodGet, "/api/projects/abc", nil, userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got models.Project
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "abc", got.ID)
+}
+
+func TestProjectsGet_NotFound(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUser(http.MethodGet, "/api/projects/missing", nil, userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorCode(t, w, ErrCodeNotFound)
+}
+
+// -- CREATE --
+
+func TestProjectsCreate_HappyPath(t *testing.T) {
+	store := newFakeStore()
+	h := newProjectsHandlerWithFake(store)
+
+	body := mustJSON(t, map[string]any{
+		"name":     "test-project",
+		"platform": "manual",
+	})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleUser)))
+
+	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+	var got models.Project
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.NotEmpty(t, got.ID, "store should assign an ID via the fake")
+	assert.Equal(t, "test-project", got.Name)
+	assert.Equal(t, models.ProjectTypeBugBounty, got.Type, "default type when omitted")
+	assert.Equal(t, models.ProjectStatusActive, got.Status, "default status when omitted")
+	assert.Equal(t, "test-project", got.Handle, "handle defaults to name when omitted")
+}
+
+func TestProjectsCreate_DefaultsApplied(t *testing.T) {
+	store := newFakeStore()
+	h := newProjectsHandlerWithFake(store)
+	body := mustJSON(t, map[string]any{
+		"name":     "p1",
+		"handle":   "p1",
+		"platform": "manual",
+		"type":     "vdp",
+		"status":   "archived",
+	})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleUser)))
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var got models.Project
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, models.ProjectTypeVDP, got.Type)
+	assert.Equal(t, models.ProjectStatusArchived, got.Status)
+}
+
+func TestProjectsCreate_AsAdminAllowed(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	body := mustJSON(t, map[string]any{"name": "admincreate", "platform": "manual"})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleAdmin)))
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestProjectsCreate_AsReadonlyForbidden(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	body := mustJSON(t, map[string]any{"name": "x", "platform": "manual"})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assertErrorCode(t, w, ErrCodeForbidden)
+}
+
+func TestProjectsCreate_NoUserContext_Unauthorized(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	body := mustJSON(t, map[string]any{"name": "x", "platform": "manual"})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, nil))
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assertErrorCode(t, w, ErrCodeUnauthorized)
+}
+
+func TestProjectsCreate_InvalidJSON_400(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/projects", bytes.NewReader([]byte(`{not valid`)))
+	r = r.WithContext(middleware.ContextWithUser(r.Context(), userOf(auth.RoleUser)))
+	h.create(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidBody)
+}
+
+func TestProjectsCreate_EmptyName_400(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	body := mustJSON(t, map[string]any{"name": "", "platform": "manual"})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidField)
+}
+
+func TestProjectsCreate_InvalidPlatform_400(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	body := mustJSON(t, map[string]any{"name": "ok", "platform": "yahoo"})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidField)
+}
+
+func TestProjectsCreate_InvalidType_400(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	body := mustJSON(t, map[string]any{"name": "ok", "platform": "manual", "type": "nonsense"})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleUser)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assertErrorCode(t, w, ErrCodeInvalidField)
+}
+
+func TestProjectsCreate_ClientCannotSmuggleServerSetFields(t *testing.T) {
+	// Security check from the plan: client sends an `id` and `created_at`;
+	// server must IGNORE them, not use them. The decode-into-request-struct
+	// pattern means these fields aren't even in createProjectRequest, so they
+	// silently drop.
+	store := newFakeStore()
+	h := newProjectsHandlerWithFake(store)
+
+	body := mustJSON(t, map[string]any{
+		"name":       "clean",
+		"platform":   "manual",
+		"id":         "client-supplied-id",
+		"created_at": "1970-01-01T00:00:00Z",
+	})
+	w := httptest.NewRecorder()
+	h.create(w, reqWithUser(http.MethodPost, "/api/projects", body, userOf(auth.RoleUser)))
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var got models.Project
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.NotEqual(t, "client-supplied-id", got.ID,
+		"client-supplied id MUST NOT propagate; the storage layer assigns one")
+}
+
+// -- DELETE --
+
+func TestProjectsDelete_AdminSucceeds(t *testing.T) {
+	store := newFakeStore()
+	store.projects["x"] = &models.Project{ID: "x", Name: "x"}
+	h := newProjectsHandlerWithFake(store)
+
+	w := httptest.NewRecorder()
+	h.delete(w, reqWithUser(http.MethodDelete, "/api/projects/x", nil, userOf(auth.RoleAdmin)))
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String(), "204 must have empty body")
+	_, exists := store.projects["x"]
+	assert.False(t, exists, "project should be removed from store")
+}
+
+func TestProjectsDelete_NonAdminForbidden(t *testing.T) {
+	store := newFakeStore()
+	store.projects["x"] = &models.Project{ID: "x"}
+	h := newProjectsHandlerWithFake(store)
+
+	for _, role := range []auth.UserRole{auth.RoleUser, auth.RoleReadOnly} {
+		t.Run(string(role), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			h.delete(w, reqWithUser(http.MethodDelete, "/api/projects/x", nil, userOf(role)))
+			assert.Equal(t, http.StatusForbidden, w.Code)
+			assertErrorCode(t, w, ErrCodeForbidden)
+		})
+	}
+	// Project should still exist after both forbidden attempts.
+	_, exists := store.projects["x"]
+	assert.True(t, exists)
+}
+
+func TestProjectsDelete_NotFound(t *testing.T) {
+	h := newProjectsHandlerWithFake(newFakeStore())
+	w := httptest.NewRecorder()
+	h.delete(w, reqWithUser(http.MethodDelete, "/api/projects/missing", nil, userOf(auth.RoleAdmin)))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorCode(t, w, ErrCodeNotFound)
+}
+
+// -- helpers shared with other handler tests --
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func assertErrorCode(t *testing.T, w *httptest.ResponseRecorder, code string) {
+	t.Helper()
+	var got ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got),
+		"body should be a structured ErrorResponse, got: %s", w.Body.String())
+	assert.Equal(t, code, got.Error.Code)
+}

--- a/internal/web/handlers/response.go
+++ b/internal/web/handlers/response.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/pkg/utils"
+)
+
+// isNotFoundErr returns true for both storage.ErrNotFound and the raw
+// sql.ErrNoRows. The storage layer does not consistently translate the
+// driver-level sentinel to storage.ErrNotFound (see the in-progress
+// errors_impl.go refactor); handlers must accept either.
+func isNotFoundErr(err error) bool {
+	return errors.Is(err, storage.ErrNotFound) || errors.Is(err, sql.ErrNoRows)
+}
+
+// ErrorResponse is the wire format for API error responses. Wrapping the
+// error in a top-level "error" key gives clients a stable shape they can
+// switch on regardless of the underlying HTTP status code.
+type ErrorResponse struct {
+	Error ErrorDetail `json:"error"`
+}
+
+// ErrorDetail carries the structured pieces of an error response.
+// Code is a stable, machine-readable identifier ("not_found", "forbidden",
+// etc.). Message is human-readable.
+type ErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Standard error codes used across data-model handlers. Adding a new code
+// here is preferable to inventing one inline at the call site — it keeps the
+// client-facing vocabulary tractable.
+const (
+	ErrCodeNotFound     = "not_found"
+	ErrCodeForbidden    = "forbidden"
+	ErrCodeUnauthorized = "unauthorized"
+	ErrCodeInvalidBody  = "invalid_body"
+	ErrCodeInvalidField = "invalid_field"
+	ErrCodeConflict     = "conflict"
+	ErrCodeInternal     = "internal"
+)
+
+// writeJSON encodes v as JSON and writes it to w with the given status code.
+// Sets Content-Type and calls WriteHeader before encoding. If encoding fails
+// after the header is sent there is nothing to recover; logs the error and
+// returns. Callers should treat writeJSON as terminal — no further writes
+// to w should happen after it returns.
+func writeJSON(w http.ResponseWriter, status int, v any, logger *utils.Logger) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		logger.Error("Failed to encode JSON response: %v", err)
+	}
+}
+
+// writeError sends a structured error envelope as JSON. Equivalent to
+// writeJSON(w, status, ErrorResponse{Error: ErrorDetail{Code: code, Message: msg}}, logger).
+func writeError(w http.ResponseWriter, status int, code, msg string, logger *utils.Logger) {
+	writeJSON(w, status, ErrorResponse{Error: ErrorDetail{Code: code, Message: msg}}, logger)
+}
+
+// decodeJSON parses r.Body into v. Returns the raw decoder error so callers
+// can choose between writeError(400, "invalid_body", err.Error()) for client
+// errors and writeError(500, "internal", "...") for genuine bugs.
+//
+// Body size is bounded by the MaxBodySize middleware applied at the router
+// level; decodeJSON does not enforce its own limit. Unknown fields in the
+// JSON are silently ignored (the default encoding/json behavior) — this
+// preserves forward-compatibility for clients sending fields the server
+// doesn't yet recognise.
+func decodeJSON(r *http.Request, v any) error {
+	return json.NewDecoder(r.Body).Decode(v)
+}

--- a/internal/web/handlers/response_test.go
+++ b/internal/web/handlers/response_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/perplext/zerodaybuddy/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger() *utils.Logger {
+	return utils.NewLogger("", false)
+}
+
+// -- writeJSON --
+
+func TestWriteJSON_HappyPath(t *testing.T) {
+	w := httptest.NewRecorder()
+	payload := map[string]any{"name": "alpha", "n": 42}
+
+	writeJSON(w, http.StatusOK, payload, newTestLogger())
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "alpha", got["name"])
+	assert.EqualValues(t, 42, got["n"])
+}
+
+func TestWriteJSON_NilValueWritesJSONNull(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeJSON(w, http.StatusOK, nil, newTestLogger())
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "null", strings.TrimSpace(w.Body.String()))
+}
+
+func TestWriteJSON_NonEncodableTypeStillWritesStatus(t *testing.T) {
+	w := httptest.NewRecorder()
+	// Channels are not JSON-encodable; encoding errors after WriteHeader
+	// has already fired. The status should still reflect what was set.
+	writeJSON(w, http.StatusAccepted, make(chan int), newTestLogger())
+
+	assert.Equal(t, http.StatusAccepted, w.Code,
+		"status header is written before encoding attempt; must reflect the requested status")
+}
+
+func TestWriteJSON_StatusVariants(t *testing.T) {
+	for _, status := range []int{
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusNoContent,
+		http.StatusInternalServerError,
+	} {
+		w := httptest.NewRecorder()
+		writeJSON(w, status, struct{}{}, newTestLogger())
+		assert.Equal(t, status, w.Code, "status %d", status)
+	}
+}
+
+// -- writeError --
+
+func TestWriteError_StructureMatchesEnvelope(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeError(w, http.StatusNotFound, ErrCodeNotFound, "project xyz not found", newTestLogger())
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	var got ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, ErrCodeNotFound, got.Error.Code)
+	assert.Equal(t, "project xyz not found", got.Error.Message)
+}
+
+func TestWriteError_AcrossStandardCodes(t *testing.T) {
+	cases := []struct {
+		status int
+		code   string
+	}{
+		{http.StatusBadRequest, ErrCodeInvalidBody},
+		{http.StatusBadRequest, ErrCodeInvalidField},
+		{http.StatusUnauthorized, ErrCodeUnauthorized},
+		{http.StatusForbidden, ErrCodeForbidden},
+		{http.StatusConflict, ErrCodeConflict},
+		{http.StatusInternalServerError, ErrCodeInternal},
+	}
+	for _, c := range cases {
+		t.Run(c.code, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			writeError(w, c.status, c.code, "some message", newTestLogger())
+			assert.Equal(t, c.status, w.Code)
+
+			var got ErrorResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+			assert.Equal(t, c.code, got.Error.Code)
+		})
+	}
+}
+
+// -- decodeJSON --
+
+type sampleBody struct {
+	Name string `json:"name"`
+	N    int    `json:"n"`
+}
+
+func TestDecodeJSON_HappyPath(t *testing.T) {
+	body := strings.NewReader(`{"name":"alpha","n":42}`)
+	req := httptest.NewRequest(http.MethodPost, "/x", body)
+
+	var got sampleBody
+	require.NoError(t, decodeJSON(req, &got))
+	assert.Equal(t, "alpha", got.Name)
+	assert.Equal(t, 42, got.N)
+}
+
+func TestDecodeJSON_InvalidJSONReturnsError(t *testing.T) {
+	body := strings.NewReader(`{"name":"alpha", broken}`)
+	req := httptest.NewRequest(http.MethodPost, "/x", body)
+
+	var got sampleBody
+	err := decodeJSON(req, &got)
+	require.Error(t, err)
+}
+
+func TestDecodeJSON_EmptyBodyReturnsEOF(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(""))
+
+	var got sampleBody
+	err := decodeJSON(req, &got)
+	assert.ErrorIs(t, err, io.EOF, "empty body should surface as io.EOF for callers to detect")
+}
+
+func TestDecodeJSON_UnknownFieldsAreIgnored(t *testing.T) {
+	// Forward-compatibility: clients sending fields the server doesn't yet
+	// recognise should not get a 400. encoding/json's default behavior
+	// (without DisallowUnknownFields) silently drops them.
+	body := strings.NewReader(`{"name":"alpha","unknown":"keep me out","n":1}`)
+	req := httptest.NewRequest(http.MethodPost, "/x", body)
+
+	var got sampleBody
+	require.NoError(t, decodeJSON(req, &got))
+	assert.Equal(t, "alpha", got.Name)
+	assert.Equal(t, 1, got.N)
+}

--- a/internal/web/handlers/tasks.go
+++ b/internal/web/handlers/tasks.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/internal/web/middleware"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/perplext/zerodaybuddy/pkg/utils"
+)
+
+type taskStore interface {
+	GetTask(ctx context.Context, id string) (*models.Task, error)
+	ListTasks(ctx context.Context, projectID string) ([]*models.Task, error)
+}
+
+// TasksHandler exposes read-only HTTP endpoints for the Task entity.
+// Tasks are recon/scan job records created by the services, not by users.
+type TasksHandler struct {
+	store  taskStore
+	logger *utils.Logger
+}
+
+func NewTasksHandler(store storage.Store, logger *utils.Logger) *TasksHandler {
+	return &TasksHandler{store: store, logger: logger}
+}
+
+func (h *TasksHandler) RegisterRoutes(mux *http.ServeMux, authedChain []func(http.Handler) http.Handler) {
+	mux.Handle("GET /api/projects/{id}/tasks", middleware.Chain(http.HandlerFunc(h.listByProject), authedChain...))
+	mux.Handle("GET /api/tasks/{id}", middleware.Chain(http.HandlerFunc(h.get), authedChain...))
+}
+
+func (h *TasksHandler) listByProject(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	tasks, err := h.store.ListTasks(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("ListTasks(%s) failed: %v", projectID, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to list tasks", h.logger)
+		return
+	}
+	if tasks == nil {
+		tasks = []*models.Task{}
+	}
+	writeJSON(w, http.StatusOK, tasks, h.logger)
+}
+
+func (h *TasksHandler) get(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	task, err := h.store.GetTask(r.Context(), id)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "task not found", h.logger)
+			return
+		}
+		h.logger.Error("GetTask(%s) failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "failed to fetch task", h.logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, task, h.logger)
+}
+
+var _ taskStore = (storage.Store)(nil)

--- a/internal/web/handlers/tasks_test.go
+++ b/internal/web/handlers/tasks_test.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
+	"github.com/perplext/zerodaybuddy/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTaskStore struct {
+	tasks   map[string]*models.Task
+	listErr error
+	getErr  error
+}
+
+func (f *fakeTaskStore) GetTask(_ context.Context, id string) (*models.Task, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	tk, ok := f.tasks[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return tk, nil
+}
+
+func (f *fakeTaskStore) ListTasks(_ context.Context, projectID string) ([]*models.Task, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := []*models.Task{}
+	for _, tk := range f.tasks {
+		if tk.ProjectID == projectID {
+			out = append(out, tk)
+		}
+	}
+	return out, nil
+}
+
+func newTasksHandlerWithFake(s taskStore) *TasksHandler {
+	return &TasksHandler{store: s, logger: newTestLogger()}
+}
+
+func TestTasksListByProject_HappyPath(t *testing.T) {
+	store := &fakeTaskStore{tasks: map[string]*models.Task{
+		"t1": {ID: "t1", ProjectID: "p1", Type: "recon"},
+		"t2": {ID: "t2", ProjectID: "p1", Type: "scan"},
+		"t3": {ID: "t3", ProjectID: "other", Type: "recon"},
+	}}
+	h := newTasksHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/tasks", "p1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []models.Task
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestTasksListByProject_NoEntriesReturnsEmptyArray(t *testing.T) {
+	h := newTasksHandlerWithFake(&fakeTaskStore{tasks: map[string]*models.Task{}})
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/empty/tasks", "empty", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "[]\n", w.Body.String())
+}
+
+func TestTasksListByProject_StoreError500(t *testing.T) {
+	h := newTasksHandlerWithFake(&fakeTaskStore{listErr: errors.New("db down")})
+	w := httptest.NewRecorder()
+	h.listByProject(w, reqWithUserCustomPath(http.MethodGet, "/api/projects/p1/tasks", "p1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorCode(t, w, ErrCodeInternal)
+}
+
+func TestTasksGet_HappyPath(t *testing.T) {
+	store := &fakeTaskStore{tasks: map[string]*models.Task{
+		"t1": {ID: "t1", Type: "recon"},
+	}}
+	h := newTasksHandlerWithFake(store)
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/tasks/t1", "t1", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got models.Task
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "t1", got.ID)
+}
+
+func TestTasksGet_NotFound(t *testing.T) {
+	h := newTasksHandlerWithFake(&fakeTaskStore{tasks: map[string]*models.Task{}})
+	w := httptest.NewRecorder()
+	h.get(w, reqWithUserCustomPath(http.MethodGet, "/api/tasks/missing", "missing", userOf(auth.RoleReadOnly)))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorCode(t, w, ErrCodeNotFound)
+}

--- a/internal/web/handlers/test_helpers_test.go
+++ b/internal/web/handlers/test_helpers_test.go
@@ -1,0 +1,15 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/web/middleware"
+)
+
+// contextWithUserForTest is a re-export of middleware.ContextWithUser used by
+// handler test files. Centralising it here keeps the per-handler test files
+// from each importing the middleware package directly.
+func contextWithUserForTest(ctx context.Context, u *auth.User) context.Context {
+	return middleware.ContextWithUser(ctx, u)
+}

--- a/internal/web/router_test.go
+++ b/internal/web/router_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
 	"github.com/perplext/zerodaybuddy/pkg/config"
 	"github.com/perplext/zerodaybuddy/pkg/utils"
 	"github.com/jmoiron/sqlx"
@@ -293,10 +294,234 @@ func TestRouter_CORSPreflightOnUnknownRouteStillSucceeds(t *testing.T) {
 	assert.Equal(t, "http://localhost:3000", w.Header().Get("Access-Control-Allow-Origin"))
 }
 
+// =============================================================================
+// T2-2 — Data-model REST handlers integration tests
+// =============================================================================
+
+// setupCombinedBackend builds a fresh on-disk SQLite store (in t.TempDir for
+// per-test isolation) with migration-applied schema (which includes the auth
+// tables) and an auth.Service backed by the same DB. Returns the concrete
+// *storage.SQLiteStore so callers can reach .DB() for direct schema mutations
+// (e.g., elevating a user's role for admin-tier tests).
+func setupCombinedBackend(t *testing.T) (*storage.SQLiteStore, *auth.Service) {
+	t.Helper()
+	store, err := storage.NewStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	authStore := auth.NewSQLStore(store.DB())
+	logger := utils.NewLogger("", false)
+	authSvc := auth.NewService(authStore, "test-secret-32-bytes-of-padding!!", "test-issuer", logger)
+	return store, authSvc
+}
+
+// newTestServerWithStoreAndAuth builds a Server with both Store and AuthService
+// wired, suitable for full data-API tests.
+func newTestServerWithStoreAndAuth(t *testing.T) (*Server, *storage.SQLiteStore, *auth.Service) {
+	t.Helper()
+	store, authSvc := setupCombinedBackend(t)
+	srv := NewServer(
+		config.WebServerConfig{},
+		Dependencies{AuthService: authSvc, Store: store},
+		utils.NewLogger("", false),
+	)
+	return srv, store, authSvc
+}
+
+// loginAs creates a user (with RoleUser regardless of the requested role —
+// auth.Service.CreateUser always assigns RoleUser per its self-registration
+// policy) and returns a bearer token. The role parameter is honored by
+// elevating the user's role directly via the auth store after creation;
+// auth.Service has no admin endpoint exposed, so test setup uses the store
+// API directly.
+//
+// Skips creation if the user already exists (e.g., the migration-seeded
+// "admin" user) and just logs in.
+func loginAs(t *testing.T, authSvc *auth.Service, store *storage.SQLiteStore, username, password string, role auth.UserRole) string {
+	t.Helper()
+	ctx := t.Context()
+
+	// Try CreateUser; tolerate already-exists.
+	_, createErr := authSvc.CreateUser(ctx, &auth.CreateUserRequest{
+		Username: username,
+		Email:    username + "@example.com",
+		FullName: username,
+		Password: password,
+	})
+	if createErr != nil && createErr.Error() != "username already exists" {
+		t.Fatalf("CreateUser(%s) unexpected error: %v", username, createErr)
+	}
+
+	// If a non-default role was requested, elevate via the underlying auth
+	// store (the auth.Service deliberately does not expose role assignment).
+	if role != auth.RoleUser {
+		authStore := auth.NewSQLStore(store.DB())
+		u, err := authStore.GetUserByUsername(ctx, username)
+		require.NoError(t, err)
+		u.Role = role
+		require.NoError(t, authStore.UpdateUser(ctx, u))
+	}
+
+	resp, err := authSvc.Login(ctx, &auth.LoginRequest{
+		Username: username,
+		Password: password,
+	}, "127.0.0.1", "test-agent")
+	require.NoError(t, err)
+	return resp.Token
+}
+
+func TestRouter_AllDataRoutesRegistered(t *testing.T) {
+	srv, store, authSvc := newTestServerWithStoreAndAuth(t)
+	token := loginAs(t, authSvc, store, "alice", "ValidPass123!", auth.RoleUser)
+	authHeader := map[string]string{"Authorization": "Bearer " + token}
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"projects.list", http.MethodGet, "/api/projects"},
+		{"projects.get", http.MethodGet, "/api/projects/some-id"},
+		{"projects.create", http.MethodPost, "/api/projects"},
+		{"projects.delete", http.MethodDelete, "/api/projects/some-id"},
+		{"hosts.list", http.MethodGet, "/api/projects/some-id/hosts"},
+		{"hosts.get", http.MethodGet, "/api/hosts/some-id"},
+		{"endpoints.list", http.MethodGet, "/api/projects/some-id/endpoints"},
+		{"endpoints.get", http.MethodGet, "/api/endpoints/some-id"},
+		{"findings.list", http.MethodGet, "/api/projects/some-id/findings"},
+		{"findings.get", http.MethodGet, "/api/findings/some-id"},
+		{"findings.patch", http.MethodPatch, "/api/findings/some-id"},
+		{"tasks.list", http.MethodGet, "/api/projects/some-id/tasks"},
+		{"tasks.get", http.MethodGet, "/api/tasks/some-id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := doRequest(t, srv, tt.method, tt.path, nil, authHeader)
+			// A registered route can legitimately return 404 (entity-not-found
+			// from the handler). Distinguish that from an unregistered route
+			// (router default 404, plain-text body) by checking Content-Type:
+			// any registered handler in this PR returns application/json.
+			ct := w.Header().Get("Content-Type")
+			if w.Code == http.StatusNotFound {
+				assert.Contains(t, ct, "application/json",
+					"route %s %s appears unregistered: 404 with non-JSON body %q (got: %s)",
+					tt.method, tt.path, ct, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestRouter_NilStoreSkipsDataRoutes(t *testing.T) {
+	store, authSvc := setupCombinedBackend(t)
+	// Server constructed WITHOUT Store — even though store is wired into
+	// auth, the server's view of dependencies omits it.
+	srv := NewServer(
+		config.WebServerConfig{},
+		Dependencies{AuthService: authSvc},
+		utils.NewLogger("", false),
+	)
+	token := loginAs(t, authSvc, store, "alice", "ValidPass123!", auth.RoleUser)
+	authHeader := map[string]string{"Authorization": "Bearer " + token}
+
+	// Data routes 404 (never registered)
+	w := doRequest(t, srv, http.MethodGet, "/api/projects", nil, authHeader)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// Auth routes still work (login already returned a token)
+	w = doRequest(t, srv, http.MethodGet, "/api/auth/profile", nil, authHeader)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRouter_FullProjectLifecycle(t *testing.T) {
+	srv, store, authSvc := newTestServerWithStoreAndAuth(t)
+	// NB: migration 004 seeds a default user "admin" — use a distinct
+	// admin-test username to avoid the username-uniqueness conflict.
+	// auth.Service.CreateUser always assigns RoleUser; loginAs elevates
+	// admin-tier users via the auth store directly.
+	userToken := loginAs(t, authSvc, store, "alice", "ValidPass123!", auth.RoleUser)
+	adminToken := loginAs(t, authSvc, store, "admintest", "ValidPass123!", auth.RoleAdmin)
+
+	// User creates a project
+	createBody, _ := json.Marshal(map[string]any{
+		"name":     "lifecycle-test",
+		"platform": "manual",
+	})
+	w := doRequest(t, srv, http.MethodPost, "/api/projects", createBody, map[string]string{
+		"Authorization": "Bearer " + userToken,
+		"Content-Type":  "application/json",
+	})
+	require.Equal(t, http.StatusCreated, w.Code, "create failed: %s", w.Body.String())
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotEmpty(t, created.ID, "create response must include id")
+
+	// User can list and see the project
+	w = doRequest(t, srv, http.MethodGet, "/api/projects", nil, map[string]string{
+		"Authorization": "Bearer " + userToken,
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), created.ID)
+
+	// User can get the project by id
+	w = doRequest(t, srv, http.MethodGet, "/api/projects/"+created.ID, nil, map[string]string{
+		"Authorization": "Bearer " + userToken,
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// User CANNOT delete (admin required)
+	w = doRequest(t, srv, http.MethodDelete, "/api/projects/"+created.ID, nil, map[string]string{
+		"Authorization": "Bearer " + userToken,
+	})
+	assert.Equal(t, http.StatusForbidden, w.Code, "delete as RoleUser must be 403")
+
+	// Admin CAN delete
+	w = doRequest(t, srv, http.MethodDelete, "/api/projects/"+created.ID, nil, map[string]string{
+		"Authorization": "Bearer " + adminToken,
+	})
+	assert.Equal(t, http.StatusNoContent, w.Code, "delete as admin must be 204")
+
+	// Project no longer exists
+	w = doRequest(t, srv, http.MethodGet, "/api/projects/"+created.ID, nil, map[string]string{
+		"Authorization": "Bearer " + userToken,
+	})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestRouter_DataRouteEnforcesAuth — pick one new route and confirm it goes
+// through AuthMiddleware. AuthMiddleware on the authedChain returns 401 for
+// requests without a valid bearer token, proving the wiring picked up the
+// per-route middleware stack rather than skipping it.
+func TestRouter_DataRouteEnforcesAuth(t *testing.T) {
+	srv, _, _ := newTestServerWithStoreAndAuth(t)
+
+	w := doRequest(t, srv, http.MethodGet, "/api/projects", nil, nil) // no Authorization header
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestRouter_DataRouteHasSecurityHeaders — same pattern as the auth-route
+// security-header test from T2-1, applied to a data route. Proves the
+// publicChain (wrapped by authedChain) is correctly applied to data handlers.
+func TestRouter_DataRouteHasSecurityHeaders(t *testing.T) {
+	srv, store, authSvc := newTestServerWithStoreAndAuth(t)
+	token := loginAs(t, authSvc, store, "alice", "ValidPass123!", auth.RoleUser)
+
+	w := doRequest(t, srv, http.MethodGet, "/api/projects", nil, map[string]string{
+		"Authorization": "Bearer " + token,
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "default-src 'self'", w.Header().Get("Content-Security-Policy"))
+}
+
 // -- Happy path: login then use returned token to access profile --
 
 func TestRouter_LoginThenProfileWithTokenSucceeds(t *testing.T) {
 	authSvc := setupAuthBackend(t)
+	_ = authSvc // keep auth-only setup; this test predates the loginAs+store helper
 	srv := NewServer(config.WebServerConfig{}, Dependencies{AuthService: authSvc}, utils.NewLogger("", false))
 
 	// Create a user directly via the auth service to avoid coupling this test

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/perplext/zerodaybuddy/internal/auth"
+	"github.com/perplext/zerodaybuddy/internal/storage"
 	"github.com/perplext/zerodaybuddy/internal/web/handlers"
 	"github.com/perplext/zerodaybuddy/internal/web/middleware"
 	"github.com/perplext/zerodaybuddy/pkg/config"
@@ -32,9 +33,15 @@ const (
 // StaticDir is the filesystem path to serve under /static/. When empty, the
 // /static/ route is not registered. Production callers should pass an
 // absolute path so the binary works regardless of cwd.
+//
+// Store is the application's data layer. When nil, the data-model routes
+// (/api/projects, /api/hosts, etc.) are not registered. Tests construct
+// minimal servers with Dependencies{} to exercise auth-only or static-only
+// scenarios.
 type Dependencies struct {
 	AuthService *auth.Service
 	StaticDir   string
+	Store       storage.Store
 }
 
 // Server represents the web server for the ZeroDayBuddy UI
@@ -136,24 +143,39 @@ func (s *Server) buildRouter() http.Handler {
 
 	// Auth routes — registered only when AuthService is wired. Tests construct
 	// minimal servers with Dependencies{} for non-auth scenarios.
-	if s.deps.AuthService == nil {
+	if s.deps.AuthService != nil {
+		authHandler := handlers.NewAuthHandler(s.deps.AuthService, s.logger)
+		authHandler.SetProxyEnabled(s.config.ProxyEnabled)
+
+		publicAuth := s.publicChain()
+		authedAuth := s.authedChain()
+
+		mux.Handle("POST /api/auth/login", middleware.Chain(http.HandlerFunc(authHandler.Login), publicAuth...))
+		mux.Handle("POST /api/auth/register", middleware.Chain(http.HandlerFunc(authHandler.Register), publicAuth...))
+		mux.Handle("POST /api/auth/refresh", middleware.Chain(http.HandlerFunc(authHandler.RefreshToken), publicAuth...))
+
+		mux.Handle("POST /api/auth/logout", middleware.Chain(http.HandlerFunc(authHandler.Logout), authedAuth...))
+		mux.Handle("GET /api/auth/profile", middleware.Chain(http.HandlerFunc(authHandler.Profile), authedAuth...))
+		mux.Handle("POST /api/auth/change-password", middleware.Chain(http.HandlerFunc(authHandler.ChangePassword), authedAuth...))
+	} else {
 		s.logger.Warn("AuthService is nil; skipping /api/auth/* route registration")
-		return mux
 	}
 
-	authHandler := handlers.NewAuthHandler(s.deps.AuthService, s.logger)
-	authHandler.SetProxyEnabled(s.config.ProxyEnabled)
+	// Data-model routes — registered only when both Store and AuthService
+	// are wired. The handlers themselves don't gate on auth; the authedChain
+	// does. Without an AuthService, AuthMiddleware would 401 every request,
+	// so the routes would be reachable but useless — skip them too.
+	if s.deps.Store != nil && s.deps.AuthService != nil {
+		authedChain := s.authedChain()
 
-	publicAuth := s.publicChain()
-	authedAuth := s.authedChain()
-
-	mux.Handle("POST /api/auth/login", middleware.Chain(http.HandlerFunc(authHandler.Login), publicAuth...))
-	mux.Handle("POST /api/auth/register", middleware.Chain(http.HandlerFunc(authHandler.Register), publicAuth...))
-	mux.Handle("POST /api/auth/refresh", middleware.Chain(http.HandlerFunc(authHandler.RefreshToken), publicAuth...))
-
-	mux.Handle("POST /api/auth/logout", middleware.Chain(http.HandlerFunc(authHandler.Logout), authedAuth...))
-	mux.Handle("GET /api/auth/profile", middleware.Chain(http.HandlerFunc(authHandler.Profile), authedAuth...))
-	mux.Handle("POST /api/auth/change-password", middleware.Chain(http.HandlerFunc(authHandler.ChangePassword), authedAuth...))
+		handlers.NewProjectsHandler(s.deps.Store, s.logger).RegisterRoutes(mux, authedChain)
+		handlers.NewHostsHandler(s.deps.Store, s.logger).RegisterRoutes(mux, authedChain)
+		handlers.NewEndpointsHandler(s.deps.Store, s.logger).RegisterRoutes(mux, authedChain)
+		handlers.NewFindingsHandler(s.deps.Store, s.logger).RegisterRoutes(mux, authedChain)
+		handlers.NewTasksHandler(s.deps.Store, s.logger).RegisterRoutes(mux, authedChain)
+	} else if s.deps.Store == nil {
+		s.logger.Warn("Store is nil; skipping data-model route registration")
+	}
 
 	return s.applyCORS(mux)
 }


### PR DESCRIPTION
## Summary

Closes T2-2 of the codebase punch list. Builds the JSON HTTP API surface for the five core data entities on top of the router and middleware stack T2-1 (PR #19) established. **13 new endpoints, 5 new handler files, 6 commits, +2731/-14 lines.**

The work is mostly mechanical: wrap existing \`storage.Store\` methods in HTTP handlers with role-scoped auth and consistent JSON shapes. The architectural decisions (URL hierarchy, role enforcement layer, response envelope, allow-list PATCH semantics) are documented in the plan; per-handler implementation is convention-following.

## What's now reachable

| Method | Path | Auth | Notes |
|---|---|---|---|
| GET | \`/api/projects\` | any user | list all projects |
| POST | \`/api/projects\` | user/admin | create from request body |
| GET | \`/api/projects/{id}\` | any user | fetch by id |
| DELETE | \`/api/projects/{id}\` | **admin only** | cascading via storage layer |
| GET | \`/api/projects/{id}/hosts\` | any user | discovered hosts |
| GET | \`/api/hosts/{id}\` | any user | |
| GET | \`/api/projects/{id}/endpoints\` | any user | discovered endpoints |
| GET | \`/api/endpoints/{id}\` | any user | |
| GET | \`/api/projects/{id}/findings\` | any user | scan findings |
| GET | \`/api/findings/{id}\` | any user | |
| PATCH | \`/api/findings/{id}\` | user/admin | allow-list: status, severity |
| GET | \`/api/projects/{id}/tasks\` | any user | recon/scan task records |
| GET | \`/api/tasks/{id}\` | any user | |

## Plan units

- **U1** — Add \`Store storage.Store\` to \`web.Dependencies\`; thread \`a.store\` through \`App.Initialize\`
- **U2** — Response helpers (\`writeJSON\`, \`writeError\`, \`decodeJSON\`, \`isNotFoundErr\`) with structured \`{"error": {"code", "message"}}\` envelope
- **U3** — Projects handler: full CRUD; create decodes into request struct (NOT model directly) to prevent client-side ID/timestamp smuggling; admin-only DELETE
- **U4** — Hosts/Endpoints/Tasks handlers: read-only (created by recon/scan services per plan D8); structurally identical
- **U5** — Findings handler: read + unified PATCH with allow-listed fields (status, severity); pointer-fields struct distinguishes "not set" from "set to empty"
- **U6** — Wire all 5 handlers in \`buildRouter\` via per-handler \`RegisterRoutes\`; integration tests; fix pre-existing T2-1 bug where AuthService-nil branch bypassed CORS

See the plan doc (commit \`aa520eb\`) for D1-D8 architectural decisions, the High-Level Technical Design diagrams, and Risk Analysis.

## Verification gate (all 8 PASS)

| Gate | Result |
|---|---|
| \`go build ./...\` | ✅ clean |
| \`go test ./... -count=1 -race\` | ✅ 20/20 packages green |
| \`golangci-lint run --timeout=3m\` (v1.64.8) | ✅ zero issues |
| \`curl -i .../api/projects\` | ✅ 200 + JSON array + security headers |
| \`curl -X POST .../api/projects\` | ✅ 200 + assigned UUID |
| \`curl -X DELETE .../api/projects/{id}\` (admin) | ✅ 204 |
| \`curl -X PATCH .../api/findings/missing\` | ✅ 404 from handler (proves route registered) |
| \`grep -l RegisterRoutes internal/web/handlers/*.go\` | ✅ all 5 handlers expose it |

Live verified end-to-end via \`./zerodaybuddy serve --port 18082\` against a fresh \`init\` in a clean \`\$HOME\`. Logged in as the migration-seeded admin to test admin-tier endpoints.

## Side fixes included

- **CORS-on-AuthService-nil bug** (pre-existing T2-1 issue): \`buildRouter\` returned \`mux\` directly when AuthService was nil, bypassing \`applyCORS\`. Now falls through to \`applyCORS\` regardless. Caught while restructuring for U6.
- **\`isNotFoundErr\` helper** for the in-progress storage-error refactor: storage layer doesn't consistently translate \`sql.ErrNoRows\` to \`storage.ErrNotFound\` (the \`*WithErrors\` methods in \`errors_impl.go\` are the planned fix, not yet integrated). Handlers accept either via the new helper.

## What this PR does NOT do (per plan scope boundaries)

- **Pagination** — list endpoints return full slices. Storage interface change is invasive; defer until list sizes warrant. (D6)
- **Reports REST endpoints** — different storage shape (no \`UpdateReport\`); design pass deferred. (D7)
- **\`PUT /api/projects/{id}\`** — full project update (Scope merge semantics non-trivial). Brainstorm scope was List/Get/Create/Delete only.
- **Bulk-create endpoints** — storage methods exist but API design questions (partial-failure shape, idempotency keys) deferred until concrete client need.
- **WebSocket / SSE for real-time scan progress** — T4-2.
- **Templated dashboard UI** — T2-3.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1 -race\` all 20 packages pass
- [x] \`golangci-lint run\` zero issues at v1.64.8
- [x] Live curl verification of all observable behaviors (gates 4-7)
- [x] Branch contains exactly 6 commits, no ghost commits from prior branches
- [x] Per-unit test coverage: 17 projects tests, 5 each for hosts/endpoints/tasks, 14 findings tests, 12 response-helper tests, 5 integration tests = ~73 new tests
- [ ] CI on this PR: all checks should be green (test/lint/Analyze/CodeQL); \`security\` may show pre-existing Go 1.25.10 stdlib CVE waiting on upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)