### PR TITLE
chore: punch-list doc accuracy + storage NULL-scan + test reliability

### DIFF
--- a/docs/brainstorms/codebase-punch-list-requirements.md
+++ b/docs/brainstorms/codebase-punch-list-requirements.md
@@ -139,14 +139,14 @@ Each item: **what** + **where** + **effort (S/M/L)** + **why this rank** + **dep
 - Effort: M
 - Add a `"manual"` platform type. New CLI: `zerodaybuddy project create --manual --name X --scope-file scope.{yaml,json}`.
 - `App.CreateProject` factored to accept either `(platform, programHandle)` or `(scopeDoc)`.
-- Why valuable: directly unblocks individual hackers (who can't use HackerOne org-tier API) and arbitrary security work. Addresses concerns documented in `HACKERONE_HACKER_LIMITATIONS.md` and `ZERODAYBUDDY_TEST_REPORT.md`. Materially expands the addressable user base.
+- Why valuable: directly unblocks individual hackers (who can't use HackerOne org-tier API) and arbitrary security work. Addresses concerns documented in `docs/archive/HACKERONE_HACKER_LIMITATIONS.md` and `docs/archive/ZERODAYBUDDY_TEST_REPORT.md` (both moved out of the repo root by Tier 1 hygiene). Materially expands the addressable user base.
 - Depends on: nothing structurally; benefits from T2-2 if web-based project creation is wanted.
 
 **T3-2. Scope file schema**
 - Where: new `pkg/models/scopefile.go` + example in `examples/scope.yaml`
 - Effort: S-M
-- Define a YAML/JSON schema covering: `in_scope[]`, `out_of_scope[]`, asset types (`url`, `domain`, `ip`, `cidr`, `wildcard`, `mobile-android`, `mobile-ios`, `code`, `executable`, `hardware`, `other`).
-- Aligns with HackerOne and Bugcrowd asset taxonomies (per `scratch-security-standards-research.md`).
+- Define a YAML/JSON schema covering `in_scope[]` and `out_of_scope[]`. Asset types should mirror the existing `models.AssetType` enum (current values: `domain`, `ip`, `url`, `mobile`, `binary`, `container`, `smart_contract`, `repository`, `other`). Planning may decide to widen the enum to distinguish wildcard vs exact domains, separate mobile-android from mobile-ios, add CIDR/source-code/hardware — but that decision belongs in the plan, not here, and any new variants must be added to `pkg/models/models.go` first.
+- Aligns with HackerOne and Bugcrowd asset taxonomies (per `docs/archive/scratch-security-standards-research.md`).
 - Depends on: T3-1.
 
 **T3-3. HackerOne hacker-account workflow clarification**

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -13,8 +13,12 @@ import (
 )
 
 func setupTestDB(t *testing.T) *sqlx.DB {
-	db, err := sqlx.Connect("sqlite", ":memory:")
+	// Shared-cache URI + single-connection pool so auth.Service queries see
+	// the schema this function creates regardless of which pool connection
+	// they pull. Plain ":memory:" gives every connection its own private DB.
+	db, err := sqlx.Connect("sqlite", "file::memory:?cache=shared")
 	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
 
 	// Create tables
 	_, err = db.Exec(`

--- a/internal/storage/finding.go
+++ b/internal/storage/finding.go
@@ -10,20 +10,34 @@ import (
 )
 
 // findingScanDest holds the intermediate scan targets for a finding row.
+//
+// Columns that are nullable in the schema (per migrations/001_initial_schema.sql)
+// must be scanned into sql.Null* wrappers — Go's database/sql refuses to scan
+// SQL NULL into a non-pointer string/float64 and the call returns an error
+// like "converting NULL to float64 is unsupported". The bulk-import path
+// always populates these fields so the bug stays latent there; any
+// alternative ingest (web UI form, manual SQL, scope-file import) trips it.
+//
+// Nullable columns covered here: type, confidence, details, url, cwe,
+// stepsJSON, evidenceJSON, evidenceMapJSON, metadataJSON, referencesJSON,
+// affectedAssetsJSON, cvss, impact, remediation.
 type findingScanDest struct {
 	finding                                                                    models.Finding
 	findingType, confidence, url, details, cwe                                 sql.NullString
+	impact, remediation                                                        sql.NullString
+	cvss                                                                       sql.NullFloat64
 	stepsJSON, evidenceJSON, evidenceMapJSON, metadataJSON, referencesJSON, affectedAssetsJSON sql.NullString
 }
 
 // scanArgs returns pointers in column order for use with Scan/QueryRow.
+// Order MUST match findingSelectCols below.
 func (d *findingScanDest) scanArgs() []interface{} {
 	return []interface{}{
 		&d.finding.ID, &d.finding.ProjectID, &d.findingType, &d.finding.Title, &d.finding.Description,
 		&d.details, &d.finding.Severity, &d.confidence, &d.finding.Status, &d.url,
-		&d.finding.CVSS, &d.finding.CVSSVector, &d.finding.CVSSVersion, &d.cwe,
+		&d.cvss, &d.finding.CVSSVector, &d.finding.CVSSVersion, &d.cwe,
 		&d.stepsJSON, &d.evidenceJSON, &d.evidenceMapJSON, &d.metadataJSON,
-		&d.finding.Impact, &d.finding.Remediation, &d.referencesJSON, &d.finding.FoundBy, &d.finding.FoundAt,
+		&d.impact, &d.remediation, &d.referencesJSON, &d.finding.FoundBy, &d.finding.FoundAt,
 		&d.affectedAssetsJSON, &d.finding.CreatedAt, &d.finding.UpdatedAt,
 	}
 }
@@ -50,6 +64,15 @@ func (d *findingScanDest) hydrate() (*models.Finding, error) {
 	}
 	if d.cwe.Valid {
 		f.CWE = d.cwe.String
+	}
+	if d.cvss.Valid {
+		f.CVSS = d.cvss.Float64
+	}
+	if d.impact.Valid {
+		f.Impact = d.impact.String
+	}
+	if d.remediation.Valid {
+		f.Remediation = d.remediation.String
 	}
 
 	stepsStr := d.stepsJSON.String

--- a/internal/storage/finding_test.go
+++ b/internal/storage/finding_test.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/perplext/zerodaybuddy/pkg/models"
+)
+
+// TestFinding_GetWithNullableColumnsScansCleanly is a regression test for the
+// scan-NULL-into-non-pointer-Go-type bug. The schema (per
+// migrations/001_initial_schema.sql) declares `cvss`, `impact`, and
+// `remediation` as nullable. Before the fix, scanning a row where any of
+// those columns is SQL NULL crashed with "converting NULL to float64/string
+// is unsupported" — the bulk-import path always populated them so the bug
+// stayed latent until a row arrived from the web UI, manual SQL, or any
+// future scope-file import path.
+func TestFinding_GetWithNullableColumnsScansCleanly(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed a project so the finding has a valid foreign key.
+	project := &models.Project{
+		Name:      "NullScanProj",
+		Handle:    "null-scan",
+		Platform:  "hackerone",
+		StartDate: time.Now(),
+		Status:    models.ProjectStatusActive,
+		Scope: models.Scope{
+			InScope: []models.Asset{{Type: models.AssetTypeDomain, Value: "example.com"}},
+		},
+	}
+	require.NoError(t, store.CreateProject(ctx, project))
+
+	// Insert a finding row directly via SQL with the nullable columns left
+	// out — they default to NULL because the schema has no DEFAULT for them.
+	// This bypasses CreateFinding (which would zero-fill them) and reproduces
+	// the failure mode of any non-bulk-import ingest path. We reach through
+	// the Store interface to the *SQLiteStore concrete type for raw SQL.
+	sqlStore, ok := store.(*SQLiteStore)
+	require.True(t, ok, "test requires SQLiteStore concrete backend")
+	_, err := sqlStore.DB().ExecContext(ctx, `
+		INSERT INTO findings (
+			id, project_id, title, description, severity, status,
+			found_by, found_at, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		"finding-null-001", project.ID,
+		"Bare-minimum finding", "minimal description",
+		"medium", "new",
+		"regression-test", time.Now(), time.Now(), time.Now())
+	require.NoError(t, err, "raw INSERT with NULL cvss/impact/remediation must succeed")
+
+	// GetFinding: must return the row without erroring on the NULL columns,
+	// and the resulting Finding should carry the Go zero values for those
+	// fields (0 for CVSS, "" for Impact/Remediation).
+	got, err := store.GetFinding(ctx, "finding-null-001")
+	require.NoError(t, err, "GetFinding must scan NULL nullable columns cleanly")
+	assert.Equal(t, "finding-null-001", got.ID)
+	assert.Equal(t, "Bare-minimum finding", got.Title)
+	assert.Equal(t, float64(0), got.CVSS, "NULL cvss should hydrate to 0")
+	assert.Equal(t, "", got.Impact, "NULL impact should hydrate to empty string")
+	assert.Equal(t, "", got.Remediation, "NULL remediation should hydrate to empty string")
+
+	// ListFindings: same scan path, must succeed for the project.
+	findings, err := store.ListFindings(ctx, project.ID)
+	require.NoError(t, err, "ListFindings must scan NULL nullable columns cleanly")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "finding-null-001", findings[0].ID)
+}
+
+// TestFinding_GetWithPopulatedNullableColumnsRoundtrips guards the other
+// direction: a finding created with non-zero cvss/impact/remediation must
+// still roundtrip those values through GetFinding after the wrapper change.
+func TestFinding_GetWithPopulatedNullableColumnsRoundtrips(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	project := &models.Project{
+		Name:      "RoundtripProj",
+		Handle:    "roundtrip",
+		Platform:  "hackerone",
+		StartDate: time.Now(),
+		Status:    models.ProjectStatusActive,
+		Scope: models.Scope{
+			InScope: []models.Asset{{Type: models.AssetTypeDomain, Value: "example.com"}},
+		},
+	}
+	require.NoError(t, store.CreateProject(ctx, project))
+
+	finding := &models.Finding{
+		ProjectID:   project.ID,
+		Title:       "Populated finding",
+		Description: "all the fields",
+		Severity:    models.SeverityHigh,
+		Status:      models.FindingStatusNew,
+		CVSS:        7.5,
+		Impact:      "Auth bypass exposes user PII.",
+		Remediation: "Validate JWT signature on every request.",
+		FoundBy:     "regression-test",
+		FoundAt:     time.Now(),
+	}
+	require.NoError(t, store.CreateFinding(ctx, finding))
+
+	got, err := store.GetFinding(ctx, finding.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 7.5, got.CVSS)
+	assert.Equal(t, "Auth bypass exposes user PII.", got.Impact)
+	assert.Equal(t, "Validate JWT signature on every request.", got.Remediation)
+}

--- a/internal/web/router_test.go
+++ b/internal/web/router_test.go
@@ -23,8 +23,16 @@ import (
 func setupAuthBackend(t *testing.T) *auth.Service {
 	t.Helper()
 
-	db, err := sqlx.Connect("sqlite", ":memory:")
+	// Plain ":memory:" gives every pool connection its own private DB, so
+	// schema bootstrap on conn A is invisible to auth.Service queries on
+	// conn B. Shared-cache URI + single-connection pool sidesteps both.
+	// (Same fix CodeRabbit had us apply on the cookie+browser-auth tests
+	// in PR #21; the pre-existing call sites kept working by luck of the
+	// connection pool reusing one connection — one timing change away
+	// from intermittent failure.)
+	db, err := sqlx.Connect("sqlite", "file::memory:?cache=shared")
 	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
 
 	_, err = db.Exec(`


### PR DESCRIPTION
## Summary

Four small follow-ups surfaced while context-scanning for a Tier 3 brainstorm. None large enough to deserve their own PR; all related to "loose ends from PR #21 + the punch-list audit." Three independent commits.

## Changes

**Commit 1 — `test:` reliability fix (`bc23198`).** `internal/web/router_test.go` and `internal/auth/service_test.go` both opened SQLite via `sqlx.Connect("sqlite", ":memory:")` — the pooled-DB-with-private-DB-per-connection bug CodeRabbit flagged on PR #21. Switched both to `file::memory:?cache=shared` + `db.SetMaxOpenConns(1)`. Tests have been working by luck of pool reuse; one timing change away from intermittent `no such table` failures.

**Commit 2 — `fix(storage):` nullable-column scan (`a451e72`).** `findingScanDest` was scanning the nullable `cvss`, `impact`, and `remediation` columns directly into `&finding.CVSS` / `&finding.Impact` / `&finding.Remediation`, so any row with a NULL in those columns crashed `GetFinding`/`ListFindings` with `converting NULL to float64 is unsupported`. The bulk-import path always populates them so the bug stayed latent — surfaced during the T2-3 dashboard smoke test when seed rows arrived via raw SQL. We patched around it with `COALESCE` in SQL at the time; this is the real fix in the scan path. Wraps the three columns in `sql.NullFloat64` / `sql.NullString` and hydrates them in `hydrate()` with Go-zero defaults. Two regression tests cover the NULL path and the populated-roundtrip path.

**Commit 3 — `docs(punch-list):` accuracy (`c148212`).** Two fixes in `docs/brainstorms/codebase-punch-list-requirements.md` Tier 3:
- T3-1 cited `HACKERONE_HACKER_LIMITATIONS.md` + `ZERODAYBUDDY_TEST_REPORT.md` at the repo root; Tier 1 hygiene (PR #17) moved both to `docs/archive/`. Updated to the new paths.
- T3-2's asset-type list (`url`, `domain`, `ip`, `cidr`, `wildcard`, `mobile-android`, `mobile-ios`, `code`, `executable`, `hardware`, `other`) didn't match the real `models.AssetType` enum (9 values: `domain`, `ip`, `url`, `mobile`, `binary`, `container`, `smart_contract`, `repository`, `other`). Rewrote to reference the real enum and defer the widening decision to the planning phase where it belongs. Also fixed the dangling `scratch-security-standards-research.md` path.

## Test plan

- [x] `go test ./... -count=1 -short` — 20/20 packages green
- [x] New `TestFinding_GetWithNullableColumnsScansCleanly` reproduces the NULL crash before the fix and passes after
- [x] New `TestFinding_GetWithPopulatedNullableColumnsRoundtrips` guards the populated-value path
- [x] Existing `setupAuthBackend` and `setupTestDB` callers (`router_test.go` whole suite, `service_test.go` whole suite) still pass with the shared-cache DSN

## Out of scope

- The T3 brainstorm itself — paused before writing a requirements doc; will revisit when the persona evidence is firmer.
- Wider `models.AssetType` enum — that's T3-2's planning decision when the brainstorm resumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database row scanning for findings records to properly handle nullable columns (CVSS, Impact, Remediation), preventing errors when these values are absent and ensuring correct data storage.

* **Tests**
  * Enhanced test coverage for findings nullable column handling with regression tests for both populated and unpopulated scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/perplext/zerodaybuddy/pull/22)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->