### PR TITLE
feat(cli): Add 'project update --scope-file' command

### DIFF
--- a/cmd/zerodaybuddy/main.go
+++ b/cmd/zerodaybuddy/main.go
@@ -113,6 +113,7 @@ func createProjectCommand(app *core.App) *cobra.Command {
 
 	cmd.AddCommand(createProjectCreateCommand(app))
 	cmd.AddCommand(createProjectListCommand(app))
+	cmd.AddCommand(createProjectUpdateCommand(app))
 
 	return cmd
 }
@@ -218,6 +219,48 @@ func createProjectListCommand(app *core.App) *cobra.Command {
 			return app.ListProjects(cmd.Context())
 		},
 	}
+
+	return cmd
+}
+
+func createProjectUpdateCommand(app *core.App) *cobra.Command {
+	var scopeFile string
+
+	cmd := &cobra.Command{
+		Use:   "update <project-name-or-id>",
+		Short: "Update an existing project",
+		Long: `Update an existing project's scope from a YAML or JSON scope file.
+
+Example:
+  zerodaybuddy project update my-project --scope-file updated-scope.yaml`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectNameOrID := args[0]
+
+			if scopeFile == "" {
+				return fmt.Errorf("--scope-file is required")
+			}
+
+			// Validate file path.
+			if err := validation.FilePath(scopeFile); err != nil {
+				return fmt.Errorf("invalid scope file path: %w", err)
+			}
+			if !isAllowedScopeFileExt(scopeFile) {
+				return fmt.Errorf("invalid scope file: must have a .yaml, .yml, or .json extension")
+			}
+
+			// Load and validate the scope file.
+			scope, err := models.LoadScopeFile(scopeFile)
+			if err != nil {
+				return fmt.Errorf("failed to load scope file: %w", err)
+			}
+
+			return app.UpdateProjectScope(cmd.Context(), projectNameOrID, *scope)
+		},
+	}
+
+	cmd.Flags().StringVar(&scopeFile, "scope-file", "", "Path to a YAML or JSON scope file")
+	_ = cmd.MarkFlagRequired("scope-file")
 
 	return cmd
 }

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -286,6 +286,46 @@ func (a *App) ListProjects(ctx context.Context) error {
 	return nil
 }
 
+// UpdateProjectScope replaces a project's scope with contents from a scope file.
+// It validates the new scope before applying and preserves all other project fields.
+func (a *App) UpdateProjectScope(ctx context.Context, nameOrID string, newScope models.Scope) error {
+	if err := a.ensureInitialized(ctx); err != nil {
+		return fmt.Errorf("failed to initialize: %w", err)
+	}
+
+	// Validate the new scope before touching the project.
+	if err := models.ValidateScope(&newScope); err != nil {
+		return pkgerrors.ValidationError("invalid scope: %s", err.Error()).
+			WithContext("project", nameOrID)
+	}
+
+	// Try to fetch by name first (most common case), then by ID.
+	project, err := a.store.GetProjectByName(ctx, nameOrID)
+	if err != nil {
+		// Not found by name; try by ID.
+		project, err = a.store.GetProject(ctx, nameOrID)
+		if err != nil {
+			return pkgerrors.NotFoundError("project %q not found", nameOrID)
+		}
+	}
+
+	oldInScope := len(project.Scope.InScope)
+	oldOutScope := len(project.Scope.OutOfScope)
+
+	project.Scope = newScope
+
+	a.logger.Info("Updating scope for project %s (%s)", project.Name, project.ID)
+	if err := a.store.UpdateProject(ctx, project); err != nil {
+		return fmt.Errorf("failed to update project: %w", err)
+	}
+
+	fmt.Printf("Updated scope for project %s\n", project.Name)
+	fmt.Printf("  In-scope:     %d → %d targets\n", oldInScope, len(newScope.InScope))
+	fmt.Printf("  Out-of-scope: %d → %d targets\n", oldOutScope, len(newScope.OutOfScope))
+
+	return nil
+}
+
 // RunRecon runs reconnaissance on a project
 func (a *App) RunRecon(ctx context.Context, projectName string, concurrent int) error {
 	if err := a.ensureInitialized(ctx); err != nil {


### PR DESCRIPTION
## Summary

Closes #25 item 2 — **`project update --scope-file` CLI**

Adds a CLI command to update an existing project's scope from a YAML or JSON file.

## Usage

```bash
zerodaybuddy project update my-project --scope-file updated-scope.yaml
```

The command accepts either a project name or project ID as the positional argument.

## Changes

### `internal/core/app.go`
- Added `UpdateProjectScope(ctx, nameOrID, scope)` method:
  - Looks up project by name first, then by ID
  - Validates new scope via `models.ValidateScope()` before applying
  - Preserves all other project fields
  - Prints before/after asset counts

### `cmd/zerodaybuddy/main.go`
- Added `createProjectUpdateCommand()` function
- Registered under `project update` subcommand
- Flags:
  - `--scope-file` (required): path to .yaml/.yml/.json scope file
- Validation:
  - File path validation (no traversal attacks)
  - Extension allowlist check
  - Scope file parsing and validation

## Use Cases

- Scope changes during an engagement
- Correcting initial scope mistakes
- Updating after program policy changes
- Adjusting out-of-scope exclusions

## Example

```yaml
# updated-scope.yaml
in_scope:
  - type: domain
    value: '*.example.com'
  - type: url
    value: 'https://api.example.com'
out_of_scope:
  - type: domain
    value: 'admin.example.com'
```

```
$ zerodaybuddy project update acme-research --scope-file updated-scope.yaml
Updated scope for project acme-research
  In-scope:     3 → 2 targets
  Out-of-scope: 0 → 1 targets
```

## Remaining Issue #25 Items

- [x] Item 1: Dashboard scope-file upload/paste UI (PR #29)
- [x] Item 2: `project update --scope-file` CLI (this PR)
- [ ] Item 3: Hacker-tier HackerOne partial support
- [ ] Item 4: Wire Immunefi into platform registry (or remove dead client)