### PR TITLE
feat(hackerone): Add hacker-tier API fallback support

### DIFF
--- a/internal/platform/hackerone.go
+++ b/internal/platform/hackerone.go
@@ -18,12 +18,16 @@ import (
 )
 
 // ErrHackerTierToken signals that the configured HackerOne token returned 401 on
-// both the organization API and the hacker API — typically invalid credentials.
-// (If the hacker API works but the org API fails, we fall back silently.)
+// both the organization API and the hacker API. This usually means the token is
+// invalid/expired, but it can also happen for restricted accounts. As a fallback,
+// the message recommends manual project mode so the user is never fully blocked.
+// The message is built from the status alone; the raw response body is never
+// interpolated, to avoid leaking sensitive content into user-facing errors.
 var ErrHackerTierToken = errors.New(
-	"hackerone authentication failed (401): invalid API credentials or token expired. " +
-		"Check your HackerOne API token at https://hackerone.com/settings/api_token and ensure " +
-		"it hasn't been revoked.")
+	"hackerone authentication failed (401): the API token was rejected by both the organization " +
+		"and hacker APIs. Verify your token at https://hackerone.com/settings/api_token (check it " +
+		"hasn't been revoked). If the program API remains unavailable, create the project manually " +
+		"instead: zerodaybuddy project create --manual --name <name> --scope-file <scope.yaml>")
 
 // HackerOne implements the Platform interface for HackerOne
 type HackerOne struct {

--- a/internal/platform/hackerone.go
+++ b/internal/platform/hackerone.go
@@ -18,22 +18,21 @@ import (
 )
 
 // ErrHackerTierToken signals that the configured HackerOne token returned 401 on
-// a program/scope endpoint — the hallmark of a hacker-tier (non-organization)
-// account, which cannot read the program API. Callers should recommend manual
-// project mode. The message is built from the status alone; the raw response
-// body is never interpolated, to avoid leaking sensitive content into
-// user-facing errors.
+// both the organization API and the hacker API — typically invalid credentials.
+// (If the hacker API works but the org API fails, we fall back silently.)
 var ErrHackerTierToken = errors.New(
-	"hackerone authentication failed (401): this token appears to be a hacker-tier account, " +
-		"but organization-tier access is required for the program API. " +
-		"Create the project manually instead: " +
-		"zerodaybuddy project create --manual --name <name> --scope-file <scope.yaml>")
+	"hackerone authentication failed (401): invalid API credentials or token expired. " +
+		"Check your HackerOne API token at https://hackerone.com/settings/api_token and ensure " +
+		"it hasn't been revoked.")
 
 // HackerOne implements the Platform interface for HackerOne
 type HackerOne struct {
 	config *config.HackerOneConfig
 	client *ratelimit.HTTPClient
 	logger *utils.Logger
+	// useHackerAPI is set to true after a successful hacker API call, allowing
+	// subsequent requests to skip the organization API attempt.
+	useHackerAPI bool
 }
 
 // NewHackerOne creates a new HackerOne platform instance
@@ -89,7 +88,8 @@ func NewHackerOneWithRateLimiter(cfg config.HackerOneConfig, logger *utils.Logge
 }
 
 // ListPrograms lists all available bug bounty programs on HackerOne.
-// Follows JSON:API pagination links to fetch all pages of results.
+// Tries the organization API first (/programs), then falls back to the hacker
+// API (/hackers/programs) if the token doesn't have organization access.
 func (h *HackerOne) ListPrograms(ctx context.Context) ([]models.Program, error) {
 	h.logger.Debug("Listing HackerOne programs")
 
@@ -97,6 +97,34 @@ func (h *HackerOne) ListPrograms(ctx context.Context) ([]models.Program, error) 
 		return nil, fmt.Errorf("HackerOne API credentials not configured")
 	}
 
+	// Try hacker API directly if we know the token is hacker-tier.
+	if h.useHackerAPI {
+		return h.listProgramsHackerAPI(ctx)
+	}
+
+	// Try organization API first.
+	programs, err := h.listProgramsOrgAPI(ctx)
+	if err == nil {
+		return programs, nil
+	}
+
+	// On 401, try the hacker API.
+	if isUnauthorizedError(err) {
+		h.logger.Debug("Organization API returned 401, trying hacker API")
+		programs, hackerErr := h.listProgramsHackerAPI(ctx)
+		if hackerErr == nil {
+			h.useHackerAPI = true
+			return programs, nil
+		}
+		// Both APIs failed — return the hacker API error for better UX.
+		return nil, hackerErr
+	}
+
+	return nil, err
+}
+
+// listProgramsOrgAPI fetches programs from the organization API (/programs).
+func (h *HackerOne) listProgramsOrgAPI(ctx context.Context) ([]models.Program, error) {
 	var programs []models.Program
 	nextURL := fmt.Sprintf("%s/programs", h.config.APIUrl)
 
@@ -109,11 +137,29 @@ func (h *HackerOne) ListPrograms(ctx context.Context) ([]models.Program, error) 
 		nextURL = next
 	}
 
-	h.logger.Debug("Found %d HackerOne programs", len(programs))
+	h.logger.Debug("Found %d HackerOne programs (org API)", len(programs))
 	return programs, nil
 }
 
-// fetchProgramsPage fetches a single page of programs and returns the next page URL (if any).
+// listProgramsHackerAPI fetches programs from the hacker API (/hackers/programs).
+func (h *HackerOne) listProgramsHackerAPI(ctx context.Context) ([]models.Program, error) {
+	var programs []models.Program
+	nextURL := fmt.Sprintf("%s/hackers/programs", h.config.APIUrl)
+
+	for page := 0; nextURL != "" && page < maxPages; page++ {
+		pagePrograms, next, err := h.fetchProgramsPageHackerAPI(ctx, nextURL)
+		if err != nil {
+			return nil, err
+		}
+		programs = append(programs, pagePrograms...)
+		nextURL = next
+	}
+
+	h.logger.Debug("Found %d HackerOne programs (hacker API)", len(programs))
+	return programs, nil
+}
+
+// fetchProgramsPage fetches a single page of programs from the org API.
 func (h *HackerOne) fetchProgramsPage(ctx context.Context, endpoint string) ([]models.Program, string, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
@@ -121,8 +167,7 @@ func (h *HackerOne) fetchProgramsPage(ctx context.Context, endpoint string) ([]m
 	}
 
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Basic %s",
-		base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", h.config.APIKey, h.config.APIKey)))))
+	req.Header.Set("Authorization", h.authHeader())
 
 	resp, err := h.client.Do(ctx, req)
 	if err != nil {
@@ -133,8 +178,8 @@ func (h *HackerOne) fetchProgramsPage(ctx context.Context, endpoint string) ([]m
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusUnauthorized {
-			h.logger.Debug("HackerOne 401 response body: %s", string(body))
-			return nil, "", ErrHackerTierToken
+			h.logger.Debug("HackerOne org API 401 response body: %s", string(body))
+			return nil, "", &unauthorizedError{api: "org"}
 		}
 		return nil, "", fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
@@ -181,7 +226,79 @@ func (h *HackerOne) fetchProgramsPage(ctx context.Context, endpoint string) ([]m
 	return programs, response.Links.Next, nil
 }
 
-// GetProgram retrieves a specific bug bounty program from HackerOne
+// fetchProgramsPageHackerAPI fetches a single page of programs from the hacker API.
+func (h *HackerOne) fetchProgramsPageHackerAPI(ctx context.Context, endpoint string) ([]models.Program, string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", h.authHeader())
+
+	resp, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusUnauthorized {
+			h.logger.Debug("HackerOne hacker API 401 response body: %s", string(body))
+			return nil, "", ErrHackerTierToken
+		}
+		return nil, "", fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	// Hacker API response structure — similar to org API but may have different fields.
+	var response struct {
+		Data []struct {
+			ID         string `json:"id"`
+			Type       string `json:"type"`
+			Attributes struct {
+				Handle      string `json:"handle"`
+				Name        string `json:"name"`
+				Description string `json:"description"`
+				URL         string `json:"url"`
+				Policy      string `json:"policy"`
+				Currency    string `json:"currency"`
+				CreatedAt   string `json:"created_at"`
+				UpdatedAt   string `json:"updated_at"`
+			} `json:"attributes"`
+		} `json:"data"`
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	programs := make([]models.Program, 0, len(response.Data))
+	for _, p := range response.Data {
+		createdAt, _ := time.Parse(time.RFC3339, p.Attributes.CreatedAt)
+		updatedAt, _ := time.Parse(time.RFC3339, p.Attributes.UpdatedAt)
+
+		programs = append(programs, models.Program{
+			ID:          p.ID,
+			Name:        p.Attributes.Name,
+			Handle:      p.Attributes.Handle,
+			Description: p.Attributes.Description,
+			URL:         p.Attributes.URL,
+			Platform:    "hackerone",
+			Policy:      p.Attributes.Policy,
+			CreatedAt:   createdAt,
+			UpdatedAt:   updatedAt,
+		})
+	}
+
+	return programs, response.Links.Next, nil
+}
+
+// GetProgram retrieves a specific bug bounty program from HackerOne.
+// Tries the organization API first, then falls back to the hacker API.
 func (h *HackerOne) GetProgram(ctx context.Context, handle string) (*models.Program, error) {
 	h.logger.Debug("Getting HackerOne program: %s", handle)
 
@@ -189,40 +306,58 @@ func (h *HackerOne) GetProgram(ctx context.Context, handle string) (*models.Prog
 		return nil, fmt.Errorf("HackerOne API credentials not configured")
 	}
 
-	// HackerOne API endpoint for a specific program
+	// Try hacker API directly if we know the token is hacker-tier.
+	if h.useHackerAPI {
+		return h.getProgramHackerAPI(ctx, handle)
+	}
+
+	// Try organization API first.
+	program, err := h.getProgramOrgAPI(ctx, handle)
+	if err == nil {
+		return program, nil
+	}
+
+	// On 401, try the hacker API.
+	if isUnauthorizedError(err) {
+		h.logger.Debug("Organization API returned 401, trying hacker API for program %s", handle)
+		program, hackerErr := h.getProgramHackerAPI(ctx, handle)
+		if hackerErr == nil {
+			h.useHackerAPI = true
+			return program, nil
+		}
+		return nil, hackerErr
+	}
+
+	return nil, err
+}
+
+// getProgramOrgAPI fetches a program from the organization API.
+func (h *HackerOne) getProgramOrgAPI(ctx context.Context, handle string) (*models.Program, error) {
 	endpoint := fmt.Sprintf("%s/programs/%s", h.config.APIUrl, handle)
 
-	// Create request
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set headers
 	req.Header.Set("Accept", "application/json")
-	// For hacker API tokens, the token is used as both username and password
-	req.Header.Set("Authorization", fmt.Sprintf("Basic %s",
-		base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", h.config.APIKey, h.config.APIKey)))))
+	req.Header.Set("Authorization", h.authHeader())
 
-	// Send request
 	resp, err := h.client.Do(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusUnauthorized {
-			// Do not interpolate the raw body — surface a typed, actionable error.
-			h.logger.Debug("HackerOne 401 response body: %s", string(body))
-			return nil, ErrHackerTierToken
+			h.logger.Debug("HackerOne org API 401 response body: %s", string(body))
+			return nil, &unauthorizedError{api: "org"}
 		}
 		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 
-	// Parse response
 	var response struct {
 		Data struct {
 			ID         string `json:"id"`
@@ -246,8 +381,8 @@ func (h *HackerOne) GetProgram(ctx context.Context, handle string) (*models.Prog
 	createdAt, _ := time.Parse(time.RFC3339, response.Data.Attributes.CreatedAt)
 	updatedAt, _ := time.Parse(time.RFC3339, response.Data.Attributes.UpdatedAt)
 
-	// Fetch scope
-	scope, err := h.FetchScope(ctx, handle)
+	// Fetch scope using org API.
+	scope, err := h.fetchScopeOrgAPI(ctx, handle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch scope: %w", err)
 	}
@@ -265,12 +400,89 @@ func (h *HackerOne) GetProgram(ctx context.Context, handle string) (*models.Prog
 		UpdatedAt:   updatedAt,
 	}
 
-	h.logger.Debug("Got HackerOne program: %s", program.Name)
-
+	h.logger.Debug("Got HackerOne program (org API): %s", program.Name)
 	return program, nil
 }
 
-// FetchScope fetches the scope for a bug bounty program
+// getProgramHackerAPI fetches a program from the hacker API.
+func (h *HackerOne) getProgramHackerAPI(ctx context.Context, handle string) (*models.Program, error) {
+	endpoint := fmt.Sprintf("%s/hackers/programs/%s", h.config.APIUrl, handle)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", h.authHeader())
+
+	resp, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusUnauthorized {
+			h.logger.Debug("HackerOne hacker API 401 response body: %s", string(body))
+			return nil, ErrHackerTierToken
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("program %q not found on HackerOne", handle)
+		}
+		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var response struct {
+		Data struct {
+			ID         string `json:"id"`
+			Type       string `json:"type"`
+			Attributes struct {
+				Handle      string `json:"handle"`
+				Name        string `json:"name"`
+				Description string `json:"description"`
+				URL         string `json:"url"`
+				Policy      string `json:"policy"`
+				Currency    string `json:"currency"`
+				CreatedAt   string `json:"created_at"`
+				UpdatedAt   string `json:"updated_at"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&response); decodeErr != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", decodeErr)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, response.Data.Attributes.CreatedAt)
+	updatedAt, _ := time.Parse(time.RFC3339, response.Data.Attributes.UpdatedAt)
+
+	// Fetch scope using hacker API.
+	scope, err := h.fetchScopeHackerAPI(ctx, handle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch scope: %w", err)
+	}
+
+	program := &models.Program{
+		ID:          response.Data.ID,
+		Name:        response.Data.Attributes.Name,
+		Handle:      response.Data.Attributes.Handle,
+		Description: response.Data.Attributes.Description,
+		URL:         response.Data.Attributes.URL,
+		Platform:    "hackerone",
+		Policy:      response.Data.Attributes.Policy,
+		Scope:       *scope,
+		CreatedAt:   createdAt,
+		UpdatedAt:   updatedAt,
+	}
+
+	h.logger.Debug("Got HackerOne program (hacker API): %s", program.Name)
+	return program, nil
+}
+
+// FetchScope fetches the scope for a bug bounty program.
+// Tries the organization API first, then falls back to the hacker API.
 func (h *HackerOne) FetchScope(ctx context.Context, handle string) (*models.Scope, error) {
 	h.logger.Debug("Fetching scope for HackerOne program: %s", handle)
 
@@ -278,40 +490,72 @@ func (h *HackerOne) FetchScope(ctx context.Context, handle string) (*models.Scop
 		return nil, fmt.Errorf("HackerOne API credentials not configured")
 	}
 
-	// HackerOne API endpoint for program scope
-	endpoint := fmt.Sprintf("%s/programs/%s/structured_scopes", h.config.APIUrl, handle)
+	// Try hacker API directly if we know the token is hacker-tier.
+	if h.useHackerAPI {
+		return h.fetchScopeHackerAPI(ctx, handle)
+	}
 
-	// Create request
+	// Try organization API first.
+	scope, err := h.fetchScopeOrgAPI(ctx, handle)
+	if err == nil {
+		return scope, nil
+	}
+
+	// On 401, try the hacker API.
+	if isUnauthorizedError(err) {
+		h.logger.Debug("Organization API returned 401, trying hacker API for scope %s", handle)
+		scope, hackerErr := h.fetchScopeHackerAPI(ctx, handle)
+		if hackerErr == nil {
+			h.useHackerAPI = true
+			return scope, nil
+		}
+		return nil, hackerErr
+	}
+
+	return nil, err
+}
+
+// fetchScopeOrgAPI fetches scope from the organization API.
+func (h *HackerOne) fetchScopeOrgAPI(ctx context.Context, handle string) (*models.Scope, error) {
+	endpoint := fmt.Sprintf("%s/programs/%s/structured_scopes", h.config.APIUrl, handle)
+	return h.fetchScopeFromEndpoint(ctx, endpoint, "org")
+}
+
+// fetchScopeHackerAPI fetches scope from the hacker API.
+func (h *HackerOne) fetchScopeHackerAPI(ctx context.Context, handle string) (*models.Scope, error) {
+	endpoint := fmt.Sprintf("%s/hackers/programs/%s/structured_scopes", h.config.APIUrl, handle)
+	return h.fetchScopeFromEndpoint(ctx, endpoint, "hacker")
+}
+
+// fetchScopeFromEndpoint is a shared implementation for fetching scope from either API.
+func (h *HackerOne) fetchScopeFromEndpoint(ctx context.Context, endpoint, apiName string) (*models.Scope, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set headers
 	req.Header.Set("Accept", "application/json")
-	// For hacker API tokens, the token is used as both username and password
-	req.Header.Set("Authorization", fmt.Sprintf("Basic %s",
-		base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", h.config.APIKey, h.config.APIKey)))))
+	req.Header.Set("Authorization", h.authHeader())
 
-	// Send request
 	resp, err := h.client.Do(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusUnauthorized {
-			// Do not interpolate the raw body — surface a typed, actionable error.
-			h.logger.Debug("HackerOne 401 response body: %s", string(body))
+			h.logger.Debug("HackerOne %s API 401 response body: %s", apiName, string(body))
+			if apiName == "org" {
+				return nil, &unauthorizedError{api: "org"}
+			}
 			return nil, ErrHackerTierToken
 		}
 		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 
-	// Parse response
+	// Parse response — same structure for both APIs.
 	var response struct {
 		Data []struct {
 			Attributes struct {
@@ -328,7 +572,7 @@ func (h *HackerOne) FetchScope(ctx context.Context, handle string) (*models.Scop
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Process scope items
+	// Process scope items.
 	scope := &models.Scope{
 		InScope:    make([]models.Asset, 0),
 		OutOfScope: make([]models.Asset, 0),
@@ -342,7 +586,7 @@ func (h *HackerOne) FetchScope(ctx context.Context, handle string) (*models.Scop
 			Instructions: item.Attributes.Instruction,
 		}
 
-		// Determine asset type
+		// Determine asset type.
 		switch strings.ToLower(item.Attributes.AssetType) {
 		case "url":
 			asset.Type = models.AssetTypeURL
@@ -358,7 +602,7 @@ func (h *HackerOne) FetchScope(ctx context.Context, handle string) (*models.Scop
 			asset.Type = models.AssetTypeOther
 		}
 
-		// Check if in scope
+		// Check if in scope.
 		if len(item.Attributes.EligibleFor) > 0 {
 			scope.InScope = append(scope.InScope, asset)
 		} else {
@@ -366,8 +610,8 @@ func (h *HackerOne) FetchScope(ctx context.Context, handle string) (*models.Scop
 		}
 	}
 
-	h.logger.Debug("Fetched scope for HackerOne program %s: %d in-scope, %d out-of-scope",
-		handle, len(scope.InScope), len(scope.OutOfScope))
+	h.logger.Debug("Fetched scope for HackerOne program (%s API): %d in-scope, %d out-of-scope",
+		apiName, len(scope.InScope), len(scope.OutOfScope))
 
 	return scope, nil
 }
@@ -375,4 +619,28 @@ func (h *HackerOne) FetchScope(ctx context.Context, handle string) (*models.Scop
 // GetName returns the name of the platform
 func (h *HackerOne) GetName() string {
 	return "hackerone"
+}
+
+// authHeader returns the Authorization header value for HackerOne API requests.
+// HackerOne uses the API token as both username and password for Basic auth.
+func (h *HackerOne) authHeader() string {
+	return fmt.Sprintf("Basic %s",
+		base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", h.config.APIKey, h.config.APIKey))))
+}
+
+// unauthorizedError is an internal error type to distinguish org API 401s
+// (which should trigger hacker API fallback) from hacker API 401s (terminal).
+type unauthorizedError struct {
+	api string // "org" or "hacker"
+}
+
+func (e *unauthorizedError) Error() string {
+	return fmt.Sprintf("HackerOne %s API returned 401", e.api)
+}
+
+// isUnauthorizedError checks if the error is an internal org API 401 that should
+// trigger a fallback to the hacker API.
+func isUnauthorizedError(err error) bool {
+	var unauthErr *unauthorizedError
+	return errors.As(err, &unauthErr) && unauthErr.api == "org"
 }

--- a/internal/platform/hackerone_test.go
+++ b/internal/platform/hackerone_test.go
@@ -165,7 +165,9 @@ func TestHackerOne_ListPrograms(t *testing.T) {
 			// Create test server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Verify request
-				assert.Equal(t, "/programs", r.URL.Path)
+				// A 401 on the org API (/programs) triggers a fallback to the
+				// hacker API (/hackers/programs), so accept either path.
+				assert.Contains(t, []string{"/programs", "/hackers/programs"}, r.URL.Path)
 				assert.Equal(t, "GET", r.Method)
 				assert.Equal(t, "application/json", r.Header.Get("Accept"))
 
@@ -602,7 +604,11 @@ func TestHackerOne_FetchScope(t *testing.T) {
 			// Create test server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Verify request
-				assert.Equal(t, fmt.Sprintf("/programs/%s/structured_scopes", tt.handle), r.URL.Path)
+				// A 401 on the org API (/programs/...) triggers a fallback to the
+				// hacker API (/hackers/programs/...), so accept either path.
+				orgPath := fmt.Sprintf("/programs/%s/structured_scopes", tt.handle)
+				hackerPath := fmt.Sprintf("/hackers/programs/%s/structured_scopes", tt.handle)
+				assert.Contains(t, []string{orgPath, hackerPath}, r.URL.Path)
 				assert.Equal(t, "GET", r.Method)
 
 				// Send response


### PR DESCRIPTION
## Summary

Closes #25 item 3 — **Optional hacker-tier HackerOne support**

The HackerOne API has two tiers with different capabilities:
- **Organization API** (`/programs/...`) — requires organization-tier token
- **Hacker API** (`/hackers/programs/...`) — works with personal hacker tokens

Previously, hacker-tier tokens received a 401 error with a recommendation to use manual mode. Now the client automatically falls back to the hacker API when the organization API returns 401, enabling hacker accounts to:

- List available programs (`zerodaybuddy list-programs --platform hackerone`)
- Fetch program details and scope for project creation
- Import projects directly from HackerOne

## Implementation

The fallback is **transparent to users** — they simply configure their hacker token and all supported operations work automatically.

### New Components

| Component | Purpose |
|-----------|---------|
| `useHackerAPI` flag | Sticky fallback detection — once hacker API succeeds, skip org API attempts |
| `listProgramsOrgAPI` / `listProgramsHackerAPI` | Parallel implementations for program listing |
| `getProgramOrgAPI` / `getProgramHackerAPI` | Parallel implementations for program details |
| `fetchScopeOrgAPI` / `fetchScopeHackerAPI` | Parallel implementations for scope fetching |
| `fetchScopeFromEndpoint` | Shared implementation to reduce duplication |
| `unauthorizedError` type | Distinguishes org 401 (trigger fallback) from hacker 401 (terminal) |
| `authHeader` helper | Reduces code duplication for auth header generation |

### Flow

```
ListPrograms() / GetProgram() / FetchScope()
    │
    ├── if useHackerAPI → try hacker API directly
    │
    └── try org API
            │
            ├── success → return result
            │
            └── 401 → try hacker API
                    │
                    ├── success → set useHackerAPI, return result
                    │
                    └── 401 → return ErrHackerTierToken (invalid creds)
```

## Error Handling

- `ErrHackerTierToken` is now only returned when **both** APIs fail with 401 (invalid credentials)
- Org API 401 triggers silent fallback, not an error to the user
- Updated error message reflects this ("invalid credentials" instead of "hacker-tier requires manual mode")

## Testing Notes

- [ ] Test with organization-tier token (should use org API, not fall back)
- [ ] Test with hacker-tier token (should fall back to hacker API transparently)
- [ ] Test with invalid token (should return `ErrHackerTierToken`)
- [ ] Test `list-programs --platform hackerone` with hacker token
- [ ] Test `project create --platform hackerone --program <handle>` with hacker token

## Remaining Issue #25 Items

- [x] Item 1: Dashboard scope-file upload/paste UI (PR #29)
- [x] Item 2: `project update --scope-file` CLI (PR #30)
- [x] Item 3: Hacker-tier HackerOne partial support (this PR)
- [ ] Item 4: Wire Immunefi into platform registry (or remove dead client)