### PR TITLE
feat(immunefi): Wire Immunefi into the platform registry

### DIFF
--- a/cmd/zerodaybuddy/main.go
+++ b/cmd/zerodaybuddy/main.go
@@ -100,7 +100,7 @@ func createListProgramsCommand(app *core.App) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&platform, "platform", "p", "", "Bug bounty platform (hackerone, bugcrowd)")
+	cmd.Flags().StringVarP(&platform, "platform", "p", "", "Bug bounty platform (hackerone, bugcrowd, immunefi)")
 
 	return cmd
 }
@@ -147,7 +147,7 @@ func createProjectCreateCommand(app *core.App) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&platform, "platform", "p", "", "Bug bounty platform (hackerone, bugcrowd, manual)")
+	cmd.Flags().StringVarP(&platform, "platform", "p", "", "Bug bounty platform (hackerone, bugcrowd, immunefi, manual)")
 	cmd.Flags().StringVarP(&program, "program", "n", "", "Program name or handle (platform mode)")
 	cmd.Flags().BoolVar(&manual, "manual", false, "Create a manual project from a local scope file")
 	cmd.Flags().StringVar(&name, "name", "", "Project name (manual mode)")

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -86,6 +86,7 @@ func (a *App) Initialize(ctx context.Context) error {
 	// Initialize platforms with rate limiter
 	a.platforms["hackerone"] = platform.NewHackerOneWithRateLimiter(a.config.HackerOne, a.logger, a.rateLimiter)
 	a.platforms["bugcrowd"] = platform.NewBugcrowdWithRateLimiter(a.config.Bugcrowd, a.logger, a.rateLimiter)
+	a.platforms["immunefi"] = platform.NewImmunefiWithRateLimiter(a.config.Immunefi, a.logger, a.rateLimiter)
 
 	// Initialize services
 	// Create auth store directly from the SQLite store's DB connection

--- a/internal/core/app_test.go
+++ b/internal/core/app_test.go
@@ -84,9 +84,10 @@ func TestAppInitialize(t *testing.T) {
 	assert.NotNil(t, app.scanSvc)
 	assert.NotNil(t, app.reportSvc)
 	assert.NotNil(t, app.webSvc)
-	assert.Len(t, app.platforms, 2)
+	assert.Len(t, app.platforms, 3)
 	assert.Contains(t, app.platforms, "hackerone")
 	assert.Contains(t, app.platforms, "bugcrowd")
+	assert.Contains(t, app.platforms, "immunefi")
 }
 
 func TestAppInitializeWithoutJWTSecret(t *testing.T) {

--- a/internal/platform/immunefi.go
+++ b/internal/platform/immunefi.go
@@ -56,6 +56,35 @@ func NewImmunefi(cfg config.ImmunefiConfig, logger *utils.Logger) Platform {
 	}
 }
 
+// NewImmunefiWithRateLimiter creates a new Immunefi platform instance using a
+// shared rate limiter, mirroring the HackerOne/Bugcrowd constructors so all
+// platforms coordinate their outbound request budget through one limiter.
+func NewImmunefiWithRateLimiter(cfg config.ImmunefiConfig, logger *utils.Logger, rateLimiter *ratelimit.RateLimiter) Platform {
+	if cfg.APIUrl == "" {
+		cfg.APIUrl = immunefiDefaultAPIURL
+	}
+
+	httpClient := ratelimit.NewHTTPClient(rateLimiter, ratelimit.HTTPClientConfig{
+		Service: "immunefi",
+		Timeout: 30 * time.Second,
+		RetryConfig: ratelimit.RetryConfig{
+			MaxAttempts:     3,
+			InitialDelay:    1 * time.Second,
+			MaxDelay:        30 * time.Second,
+			Multiplier:      2.0,
+			JitterFactor:    0.1,
+			RetryableErrors: ratelimit.DefaultRetryableErrors(),
+		},
+		Logger: logger,
+	})
+
+	return &Immunefi{
+		config:     &cfg,
+		httpClient: httpClient,
+		logger:     logger,
+	}
+}
+
 func (i *Immunefi) GetName() string { return "immunefi" }
 
 // immunefiBounciesResponse represents the Immunefi bounties API response.

--- a/internal/platform/immunefi_test.go
+++ b/internal/platform/immunefi_test.go
@@ -57,6 +57,24 @@ func TestNewImmunefi(t *testing.T) {
 	})
 }
 
+func TestNewImmunefiWithRateLimiter(t *testing.T) {
+	logger := utils.NewLogger("", true)
+	rateLimiter := ratelimit.New(ratelimit.DefaultConfig())
+
+	t.Run("default API URL", func(t *testing.T) {
+		cfg := config.ImmunefiConfig{}
+		p := NewImmunefiWithRateLimiter(cfg, logger, rateLimiter)
+		assert.NotNil(t, p)
+		assert.Equal(t, "immunefi", p.GetName())
+	})
+
+	t.Run("custom API URL", func(t *testing.T) {
+		cfg := config.ImmunefiConfig{APIUrl: "https://custom.api.com"}
+		p := NewImmunefiWithRateLimiter(cfg, logger, rateLimiter)
+		assert.NotNil(t, p)
+	})
+}
+
 func TestImmunefi_ListPrograms_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/bounties", r.URL.Path)

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// Error types
-	ErrInvalidPlatform     = errors.New("invalid platform: must be one of 'hackerone', 'bugcrowd', or 'manual'")
+	ErrInvalidPlatform     = errors.New("invalid platform: must be one of 'hackerone', 'bugcrowd', 'immunefi', or 'manual'")
 	ErrInvalidConcurrency  = errors.New("invalid concurrency: must be between 1 and 100")
 	ErrInvalidPort         = errors.New("invalid port: must be between 1 and 65535")
 	ErrPrivilegedPort      = errors.New("privileged port: ports below 1024 require root privileges")
@@ -37,7 +37,7 @@ var (
 )
 
 // ValidPlatforms contains the list of supported bug bounty platforms
-var ValidPlatforms = []string{"hackerone", "bugcrowd", "manual"}
+var ValidPlatforms = []string{"hackerone", "bugcrowd", "immunefi", "manual"}
 
 // ValidReportFormats contains the list of supported report formats
 var ValidReportFormats = []string{"markdown", "pdf"}

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -16,6 +16,7 @@ func TestPlatform(t *testing.T) {
 	}{
 		{"valid hackerone", "hackerone", false},
 		{"valid bugcrowd", "bugcrowd", false},
+		{"valid immunefi", "immunefi", false},
 		{"valid manual", "manual", false},
 		{"valid with spaces", " hackerone ", false},
 		{"valid uppercase", "BUGCROWD", false},


### PR DESCRIPTION
## Summary

Closes #25 item 4 — **Wire Immunefi into the platform registry (or remove the dead client)**

The Immunefi client (`internal/platform/immunefi.go`) already implemented the `Platform` interface and had test coverage, but it was never registered in `App.Initialize`, and `immunefi` was missing from `validation.ValidPlatforms`. As a result, `--platform immunefi` produced a runtime "unknown platform" error.

**Decision: wire it in** (rather than delete). The client is complete and tested — it only needed registration. This matches the issue note that adding it to `ValidPlatforms` *alone* would fail; this PR does the full end-to-end wiring.

## Changes

| File | Change |
|------|--------|
| `internal/platform/immunefi.go` | Add `NewImmunefiWithRateLimiter` constructor mirroring the HackerOne/Bugcrowd variants, so Immunefi shares the app-wide rate limiter instead of creating its own |
| `internal/core/app.go` | Register `immunefi` in `App.Initialize()` alongside `hackerone` and `bugcrowd` |
| `pkg/validation/validation.go` | Add `immunefi` to `ValidPlatforms`; update `ErrInvalidPlatform` message |
| `cmd/zerodaybuddy/main.go` | Update `--platform` help text for `list-programs` and `project create` |
| `internal/platform/immunefi_test.go` | Add `TestNewImmunefiWithRateLimiter` |
| `pkg/validation/validation_test.go` | Add `immunefi` case to `TestPlatform` |

## Now Supported

```bash
zerodaybuddy list-programs --platform immunefi
zerodaybuddy project create --platform immunefi --program <handle>
```

## Why shared rate limiter?

HackerOne and Bugcrowd both use `*WithRateLimiter` constructors so all outbound platform requests coordinate through one limiter (`a.rateLimiter`). Immunefi previously only had `NewImmunefi`, which spun up its own limiter. Adding the `WithRateLimiter` variant keeps all three platforms consistent and prevents Immunefi from bypassing the shared request budget.

## Testing Notes

- [ ] `list-programs --platform immunefi` returns active bounties
- [ ] `project create --platform immunefi --program <handle>` imports scope
- [ ] Invalid platform still rejected with updated error message
- [ ] `go test ./pkg/validation/... ./internal/platform/...` passes

## Issue #25 — All Items Complete ✅

- [x] Item 1: Dashboard scope-file upload/paste UI ([PR #29](https://github.com/perplext/zerodaybuddy/pull/29))
- [x] Item 2: `project update --scope-file` CLI ([PR #30](https://github.com/perplext/zerodaybuddy/pull/30))
- [x] Item 3: Hacker-tier HackerOne partial support ([PR #31](https://github.com/perplext/zerodaybuddy/pull/31))
- [x] Item 4: Wire Immunefi into platform registry (this PR)